### PR TITLE
Rename TestingType into RustType

### DIFF
--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -1,4 +1,4 @@
-pub(in crate) fn fragment_components_from_fragment(fragment: &str) -> Box<Iterator<Item = String>> {
+pub(in crate) fn fragment_components_from_fragment(fragment: &str) -> Box<dyn Iterator<Item = String>> {
     let fragment = fragment.trim_start_matches('/');
     if fragment.is_empty() {
         Box::new(Vec::with_capacity(0).into_iter())

--- a/src/index.rs
+++ b/src/index.rs
@@ -51,11 +51,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::Index;
-    use crate::{json_type::JsonType, testing::TestingType};
+    use crate::{json_type::JsonType, rust_type::RustType};
 
     #[test]
     fn test_into_index_vec() {
-        let testing_vec: TestingType = testing_vec![(), true, "v3", 4, testing_vec![1, 2, 3], testing_map![],];
+        let testing_vec: RustType = testing_vec![(), true, "v3", 4, testing_vec![1, 2, 3], testing_map![],];
 
         let testing_object = testing_vec.clone();
         for (k, v) in testing_vec.as_array().unwrap().enumerate() {
@@ -81,7 +81,7 @@ mod tests {
             "k6" => testing_map![],
         ];
 
-        if let TestingType::Object(ref hash_map) = &testing_map {
+        if let RustType::Object(ref hash_map) = &testing_map {
             for (k, v) in hash_map {
                 assert_eq!(k.as_str().index_into(&testing_map), Some(v), "failed with k={}\n", k);
             }
@@ -108,7 +108,7 @@ mod tests {
             "k6" => testing_map![],
         ];
 
-        if let TestingType::Object(ref hash_map) = &testing_map {
+        if let RustType::Object(ref hash_map) = &testing_map {
             for (k, v) in hash_map {
                 assert_eq!(k.index_into(&testing_map), Some(v), "failed with k={}\n", k);
             }

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -232,7 +232,7 @@ mod enum_primitive_type_tests {
 mod primitive_type_tests {
     #[allow(unused_imports)]
     use crate::json_type::JsonType;
-    use crate::testing::TestingType;
+    use crate::rust_type::RustType;
     use test_case_derive::test_case;
 
     #[test_case("", Some(&testing_map![
@@ -253,12 +253,12 @@ mod primitive_type_tests {
         1,
         "2"
     ]))]
-    #[test_case("/key/inner_key/0", Some(&TestingType::from(1)))]
-    #[test_case("/key/inner_key/1", Some(&TestingType::from("2")))]
+    #[test_case("/key/inner_key/0", Some(&RustType::from(1)))]
+    #[test_case("/key/inner_key/1", Some(&RustType::from("2")))]
     #[test_case("/not_present", None)]
     #[test_case("/key/inner_key/a", None)]
     #[test_case("/key/inner_key/2", None)]
-    fn test_get_fragment(fragment: &str, expected_value: Option<&TestingType>) {
+    fn test_get_fragment(fragment: &str, expected_value: Option<&RustType>) {
         let external_map = testing_map![
             "key" => testing_map![
                 "inner_key" => testing_vec![

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -49,23 +49,23 @@ where
     T: 'json + JsonType,
 {
     #[inline]
-    fn keys(&'json self) -> Box<ExactSizeIterator<Item = &str> + 'json> {
+    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json> {
         Box::new(self.items().map(|(key, _)| key))
     }
 
     #[inline]
-    fn values(&'json self) -> Box<ExactSizeIterator<Item = &T> + 'json> {
+    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &T> + 'json> {
         Box::new(self.items().map(|(_, value)| value))
     }
 
-    fn items(&'json self) -> Box<ExactSizeIterator<Item = (&str, &T)> + 'json>;
+    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &T)> + 'json>;
 }
 
 // This trait allows us to have a 1:1 mapping with serde_json, generally used by rust libraries
 // but gives us the power to use different objects from serde_json. This gives us the ability
 // to support usage of different data-types like PyObject from pyo3 in case of python bindings
 pub trait JsonType: Clone + Debug + PartialEq + Sync + Send {
-    fn as_array<'json>(&'json self) -> Option<Box<ExactSizeIterator<Item = &Self> + 'json>>;
+    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>>;
     fn as_boolean(&self) -> Option<bool>;
     fn as_integer(&self) -> Option<i128>;
     fn as_null(&self) -> Option<()>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ mod macros;
 mod fragment;
 mod index;
 mod json_type;
-mod testing;
+mod rust_type;
 pub mod traits;
 
 pub use json_type::{EnumJsonType, JsonMap, JsonMapTrait, JsonType};
-pub use testing::TestingType;
+pub use rust_type::RustType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,8 @@ extern crate lazy_static;
 extern crate serde_json;
 
 // Macros have to be imported first to allow usage on other modules
-#[cfg(test)]
 #[macro_use]
-mod macros;
+pub mod macros;
 
 mod fragment;
 mod index;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,14 +4,14 @@ macro_rules! testing_map {
         testing_map![$($k => $v),*]
     }};
     ($($k: expr => $v: expr),*) => {{
-        use crate::testing::TestingType;
+        use $crate::RustType;
         use std::collections::hash_map::HashMap;
 
         // Variable definition is needed to ensure that the resulting type is known in the context
         #[allow(unused_mut)]
-        let mut thing: HashMap<String, TestingType> = HashMap::default();
-        $( let _ = thing.insert($k.to_string(), TestingType::from($v)); )*
-        TestingType::from(thing)
+        let mut thing: HashMap<String, RustType> = HashMap::default();
+        $( let _ = thing.insert($k.to_string(), RustType::from($v)); )*
+        RustType::from(thing)
     }};
 }
 
@@ -21,13 +21,13 @@ macro_rules! testing_vec {
         testing_vec![$($item),*]
     }};
     ($($item: expr),*) => {{
-        use crate::testing::TestingType;
+        use $crate::RustType;
 
         // Variable definition is needed to ensure that the resulting type is known in the context
-        let thing: Vec<TestingType> = vec![
-            $( TestingType::from($item), )*
+        let thing: Vec<RustType> = vec![
+            $( RustType::from($item), )*
         ];
-        TestingType::from(thing)
+        RustType::from(thing)
     }};
 }
 

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -61,7 +61,7 @@ impl From<Vec<RustType>> for RustType {
 }
 
 impl JsonType for RustType {
-    fn as_array<'json>(&'json self) -> Option<Box<ExactSizeIterator<Item = &Self> + 'json>> {
+    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         match self {
             RustType::List(v) => Some(Box::new(v.iter())),
             _ => None,
@@ -138,7 +138,7 @@ impl JsonType for RustType {
 
 impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
     #[inline]
-    fn items(&'json self) -> Box<ExactSizeIterator<Item = (&str, &RustType)> + 'json> {
+    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &RustType)> + 'json> {
         if let RustType::Object(hash_map) = self.deref() {
             Box::new(hash_map.iter().map(|(k, v)| (k.as_str(), v)))
         } else {

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -3,73 +3,73 @@ use std::{collections::hash_map::HashMap, ops::Deref};
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum TestingType {
+pub enum RustType {
     Null,
     Boolean(bool),
     String(String),
     Integer(i32),
-    List(Vec<TestingType>),
-    Object(HashMap<String, TestingType>),
+    List(Vec<RustType>),
+    Object(HashMap<String, RustType>),
 }
 
-impl Default for TestingType {
+impl Default for RustType {
     fn default() -> Self {
-        TestingType::Null
+        RustType::Null
     }
 }
 
-impl From<()> for TestingType {
+impl From<()> for RustType {
     fn from(_: ()) -> Self {
-        TestingType::Null
+        RustType::Null
     }
 }
 
-impl From<bool> for TestingType {
+impl From<bool> for RustType {
     fn from(value: bool) -> Self {
-        TestingType::Boolean(value)
+        RustType::Boolean(value)
     }
 }
 
-impl From<&str> for TestingType {
+impl From<&str> for RustType {
     fn from(value: &str) -> Self {
-        TestingType::String(String::from(value))
+        RustType::String(String::from(value))
     }
 }
 
-impl From<String> for TestingType {
+impl From<String> for RustType {
     fn from(value: String) -> Self {
-        TestingType::String(value)
+        RustType::String(value)
     }
 }
 
-impl From<i32> for TestingType {
+impl From<i32> for RustType {
     fn from(value: i32) -> Self {
-        TestingType::Integer(value)
+        RustType::Integer(value)
     }
 }
 
-impl From<HashMap<String, TestingType>> for TestingType {
+impl From<HashMap<String, RustType>> for RustType {
     fn from(value: HashMap<String, Self>) -> Self {
-        TestingType::Object(value)
+        RustType::Object(value)
     }
 }
 
-impl From<Vec<TestingType>> for TestingType {
+impl From<Vec<RustType>> for RustType {
     fn from(value: Vec<Self>) -> Self {
-        TestingType::List(value)
+        RustType::List(value)
     }
 }
 
-impl JsonType for TestingType {
+impl JsonType for RustType {
     fn as_array<'json>(&'json self) -> Option<Box<ExactSizeIterator<Item = &Self> + 'json>> {
         match self {
-            TestingType::List(v) => Some(Box::new(v.iter())),
+            RustType::List(v) => Some(Box::new(v.iter())),
             _ => None,
         }
     }
 
     fn as_boolean(&self) -> Option<bool> {
-        if let TestingType::Boolean(v) = self {
+        if let RustType::Boolean(v) = self {
             Some(*v)
         } else {
             None
@@ -77,7 +77,7 @@ impl JsonType for TestingType {
     }
 
     fn as_integer(&self) -> Option<i128> {
-        if let TestingType::Integer(v) = self {
+        if let RustType::Integer(v) = self {
             Some(i128::from(*v))
         } else {
             None
@@ -85,7 +85,7 @@ impl JsonType for TestingType {
     }
 
     fn as_null(&self) -> Option<()> {
-        if let TestingType::Null = self {
+        if let RustType::Null = self {
             Some(())
         } else {
             None
@@ -93,7 +93,7 @@ impl JsonType for TestingType {
     }
 
     fn as_number(&self) -> Option<f64> {
-        if let TestingType::Integer(v) = self {
+        if let RustType::Integer(v) = self {
             Some(f64::from(*v))
         } else {
             None
@@ -104,7 +104,7 @@ impl JsonType for TestingType {
     where
         JsonMap<'json, Self>: JsonMapTrait<'json, Self>,
     {
-        if let TestingType::Object(_) = self {
+        if let RustType::Object(_) = self {
             Some(JsonMap::new(self))
         } else {
             None
@@ -112,7 +112,7 @@ impl JsonType for TestingType {
     }
 
     fn as_string(&self) -> Option<&str> {
-        if let TestingType::String(s) = self {
+        if let RustType::String(s) = self {
             Some(s)
         } else {
             None
@@ -120,7 +120,7 @@ impl JsonType for TestingType {
     }
 
     fn get_attribute<R: AsRef<str>>(&self, attribute_name: R) -> Option<&Self> {
-        if let TestingType::Object(object) = self {
+        if let RustType::Object(object) = self {
             object.get(attribute_name.as_ref())
         } else {
             None
@@ -128,7 +128,7 @@ impl JsonType for TestingType {
     }
 
     fn get_index(&self, index: usize) -> Option<&Self> {
-        if let TestingType::List(array) = self {
+        if let RustType::List(array) = self {
             array.get(index)
         } else {
             None
@@ -136,10 +136,10 @@ impl JsonType for TestingType {
     }
 }
 
-impl<'json> JsonMapTrait<'json, TestingType> for JsonMap<'json, TestingType> {
+impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
     #[inline]
-    fn items(&'json self) -> Box<ExactSizeIterator<Item = (&str, &TestingType)> + 'json> {
-        if let TestingType::Object(hash_map) = self.deref() {
+    fn items(&'json self) -> Box<ExactSizeIterator<Item = (&str, &RustType)> + 'json> {
+        if let RustType::Object(hash_map) = self.deref() {
             Box::new(hash_map.iter().map(|(k, v)| (k.as_str(), v)))
         } else {
             #[allow(unsafe_code)]
@@ -154,14 +154,14 @@ impl<'json> JsonMapTrait<'json, TestingType> for JsonMap<'json, TestingType> {
 mod smoke_test {
     use crate::{
         json_type::{JsonMapTrait, JsonType},
-        testing::TestingType,
+        rust_type::RustType,
     };
     use std::collections::hash_map::HashMap;
 
     #[test]
     fn test_testing_type_instance_string() {
         let string = "string";
-        let testing_type_instance = TestingType::from(string);
+        let testing_type_instance = RustType::from(string);
         assert_eq!(testing_type_instance.as_string(), Some(string));
         assert_eq!(testing_type_instance.has_attribute("attribute"), false);
         assert_eq!(testing_type_instance.is_array(), false);
@@ -176,7 +176,7 @@ mod smoke_test {
     #[test]
     fn test_testing_type_instance_integer() {
         let integer = 1;
-        let testing_type_instance = TestingType::from(integer);
+        let testing_type_instance = RustType::from(integer);
         assert_eq!(testing_type_instance.as_integer(), Some(i128::from(integer)));
         assert_eq!(testing_type_instance.has_attribute("attribute"), false);
         assert_eq!(testing_type_instance.is_array(), false);
@@ -190,8 +190,8 @@ mod smoke_test {
 
     #[test]
     fn test_testing_type_instance_list() {
-        let array = vec![TestingType::from(1), TestingType::from(2)];
-        let testing_type_instance = TestingType::from(array.clone());
+        let array = vec![RustType::from(1), RustType::from(2)];
+        let testing_type_instance = RustType::from(array.clone());
         assert_eq!(
             testing_type_instance.as_array().and_then(|iterator| Some(iterator.collect::<Vec<_>>())),
             Some(array.iter().collect())
@@ -208,13 +208,13 @@ mod smoke_test {
 
     #[test]
     fn test_testing_type_instance_object() {
-        let object: HashMap<String, TestingType> = [("attribute".to_string(), TestingType::from("value"))].iter().cloned().collect();
-        let testing_type_instance = TestingType::from(object);
+        let object: HashMap<String, RustType> = [("attribute".to_string(), RustType::from("value"))].iter().cloned().collect();
+        let testing_type_instance = RustType::from(object);
         assert_eq!(
             testing_type_instance.as_object().unwrap().items().collect::<Vec<_>>(),
-            vec![("attribute", &TestingType::from("value"))],
+            vec![("attribute", &RustType::from("value"))],
         );
-        assert_eq!(testing_type_instance.get("attribute"), Some(&TestingType::from("value")));
+        assert_eq!(testing_type_instance.get("attribute"), Some(&RustType::from("value")));
         assert_eq!(testing_type_instance.has_attribute("attribute"), true);
         assert_eq!(testing_type_instance.is_array(), false);
         assert_eq!(testing_type_instance.is_boolean(), false);

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -4,26 +4,26 @@ use std::ops::Index;
 
 impl<'json> JsonMapTrait<'json, json::JsonValue> for JsonMap<'json, json::JsonValue> {
     #[inline]
-    fn keys(&'json self) -> Box<ExactSizeIterator<Item = &str> + 'json> {
+    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json> {
         // TODO: remove .collect().into_iter() once https://github.com/maciejhirsz/json-rust/pull/156 is merged
         Box::new(self.entries().map(|(key, _)| key).collect::<Vec<_>>().into_iter())
     }
 
     #[inline]
-    fn values(&'json self) -> Box<ExactSizeIterator<Item = &json::JsonValue> + 'json> {
+    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &json::JsonValue> + 'json> {
         // TODO: remove .collect().into_iter() once https://github.com/maciejhirsz/json-rust/pull/156 is merged
         Box::new(self.entries().map(|(_, value)| value).collect::<Vec<_>>().into_iter())
     }
 
     #[inline]
-    fn items(&'json self) -> Box<ExactSizeIterator<Item = (&str, &json::JsonValue)> + 'json> {
+    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &json::JsonValue)> + 'json> {
         // TODO: remove .collect().into_iter() once https://github.com/maciejhirsz/json-rust/pull/156 is merged
         Box::new(self.entries().collect::<Vec<_>>().into_iter())
     }
 }
 
 impl JsonType for json::JsonValue {
-    fn as_array<'json>(&'json self) -> Option<Box<ExactSizeIterator<Item = &Self> + 'json>> {
+    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if self.is_array() {
             Some(Box::new(self.members()))
         } else {

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -3,7 +3,7 @@ use serde_json;
 
 impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json::Value> {
     #[inline]
-    fn keys(&'json self) -> Box<ExactSizeIterator<Item = &str> + 'json> {
+    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.keys().map(String::as_str))
         } else {
@@ -15,7 +15,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 
     #[inline]
-    fn values(&'json self) -> Box<ExactSizeIterator<Item = &serde_json::Value> + 'json> {
+    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &serde_json::Value> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.values())
         } else {
@@ -27,7 +27,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 
     #[inline]
-    fn items(&'json self) -> Box<ExactSizeIterator<Item = (&str, &serde_json::Value)> + 'json> {
+    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &serde_json::Value)> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.iter().map(|(key, value)| (key.as_str(), value)))
         } else {
@@ -40,7 +40,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
 }
 
 impl JsonType for serde_json::Value {
-    fn as_array<'json>(&'json self) -> Option<Box<ExactSizeIterator<Item = &Self> + 'json>> {
+    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_array() {
             Some(Box::new(vec.iter()))
         } else {

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -3,7 +3,7 @@ use serde_yaml;
 
 impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml::Value> {
     #[inline]
-    fn keys(&'json self) -> Box<ExactSizeIterator<Item = &str> + 'json> {
+    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(key, _)| (key.as_str().unwrap())))
         } else {
@@ -15,7 +15,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 
     #[inline]
-    fn values(&'json self) -> Box<ExactSizeIterator<Item = &serde_yaml::Value> + 'json> {
+    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &serde_yaml::Value> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(_, value)| value))
         } else {
@@ -27,7 +27,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 
     #[inline]
-    fn items(&'json self) -> Box<ExactSizeIterator<Item = (&str, &serde_yaml::Value)> + 'json> {
+    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &serde_yaml::Value)> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(key, value)| (key.as_str().unwrap(), value)))
         } else {
@@ -40,7 +40,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
 }
 
 impl JsonType for serde_yaml::Value {
-    fn as_array<'json>(&'json self) -> Option<Box<ExactSizeIterator<Item = &Self> + 'json>> {
+    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_sequence() {
             Some(Box::new(vec.iter()))
         } else {


### PR DESCRIPTION
This PR renames ``json_trait_rs::TestingType`` into ``json_trait_rs::RustType``.
This is done because external libraries might take advantage of it and it would be "not nice" to force them to have to use an additional feature.

NOTE: As  ``TestingType`` or ``RustType`` depends on rust specific information (no other dependencies) it would not add much binary code in the final artifact.