### PR TITLE
Add Cargo categories and patch test-case-derive to allow testing on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+rust: stable
 
 env:
   global:
@@ -11,7 +12,6 @@ matrix:
   # TODO: add osx and windows testing environments
   - os: linux
     dist: xenial
-    rust: nightly
     env: MAKE_TARGET=coverage
     addons:
       apt:
@@ -25,15 +25,12 @@ matrix:
   - os: linux
     dist: xenial
     env: MAKE_TARGET=test
-    rust: nightly  # TODO: set it to stable once https://github.com/synek317/test-case-derive/pull/5 is released
   - os: linux
     dist: xenial
     env: MAKE_TARGET=doc
-    rust: stable
   - os: linux
     dist: xenial
     env: MAKE_TARGET=lint
-    rust: nightly  # TODO: set it to stable once https://github.com/synek317/test-case-derive/pull/5 is released
   allow_failures:
   - env: MAKE_TARGET=lint
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 authors = ["Samuele Maci <macisamuele@gmail.com>"]
+categories = ["data-structures", "development-tools", "encoding", "parsing"]
 description = "Rust interface (aka trait) to deal with objects as they are JSON objects"
 repository = "https://github.com/macisamuele/json-trait-rs"
 edition = "2018"
@@ -37,3 +38,7 @@ serde_yaml = { version = "0", optional = true }
 strum = "0"
 strum_macros = "0"
 unreachable = "1"
+
+[patch.crates-io]
+# TODO: Remove patch once https://github.com/synek317/test-case-derive/pull/5 is merged
+test-case-derive = { git = "https://github.com/macisamuele/test-case-derive", branch = "maci-allow-build-on-stable"}


### PR DESCRIPTION
The goal of this PR is to ensure that tests are executed on Rust stable version.

In order to workaround the limitation of [synek317/test-case-derive](https://github.com/synek317/test-case-derive) I'm going to patch the crates.io resolution (as documented [here](https://doc.rust-lang.org/edition-guide/rust-2018/cargo-and-crates-io/replacing-dependencies-with-patch.html)) by using the branch related to https://github.com/synek317/test-case-derive/pull/5