### PR TITLE
Rename macros (testing_(map|vec) into rust_type_(map|vec))

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   - id: check-yaml
   - id: check-added-large-files
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v1.2.2
+  rev: v1.2.4
   hooks:
   - id: pretty-format-rust
     args: [--autofix]

--- a/src/index.rs
+++ b/src/index.rs
@@ -55,7 +55,7 @@ mod tests {
 
     #[test]
     fn test_into_index_vec() {
-        let testing_vec: RustType = testing_vec![(), true, "v3", 4, testing_vec![1, 2, 3], testing_map![],];
+        let testing_vec: RustType = rust_type_vec![(), true, "v3", 4, rust_type_vec![1, 2, 3], rust_type_map![],];
 
         let testing_object = testing_vec.clone();
         for (k, v) in testing_vec.as_array().unwrap().enumerate() {
@@ -72,13 +72,13 @@ mod tests {
 
     #[test]
     fn test_into_index_map_str() {
-        let testing_map = testing_map![
+        let testing_map = rust_type_map![
             "k1" => (),
             "k2" => true,
             "k3" => "v3",
             "k4" => 4,
-            "k5" => testing_vec![1,2,3],
-            "k6" => testing_map![],
+            "k5" => rust_type_vec![1,2,3],
+            "k6" => rust_type_map![],
         ];
 
         if let RustType::Object(ref hash_map) = &testing_map {
@@ -99,13 +99,13 @@ mod tests {
 
     #[test]
     fn test_into_index_map_string() {
-        let testing_map = testing_map![
+        let testing_map = rust_type_map![
             "k1" => (),
             "k2" => true,
             "k3" => "v3",
             "k4" => 4,
-            "k5" => testing_vec![1,2,3],
-            "k6" => testing_map![],
+            "k5" => rust_type_vec![1,2,3],
+            "k6" => rust_type_map![],
         ];
 
         if let RustType::Object(ref hash_map) = &testing_map {

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -235,21 +235,21 @@ mod primitive_type_tests {
     use crate::rust_type::RustType;
     use test_case_derive::test_case;
 
-    #[test_case("", Some(&testing_map![
-        "key" => testing_map![
-            "inner_key" => testing_vec![
+    #[test_case("", Some(&rust_type_map![
+        "key" => rust_type_map![
+            "inner_key" => rust_type_vec![
                 1,
                 "2"
             ],
         ],
     ]))]
-    #[test_case("/key", Some(&testing_map![
-        "inner_key" => testing_vec![
+    #[test_case("/key", Some(&rust_type_map![
+        "inner_key" => rust_type_vec![
             1,
             "2"
         ],
     ]))]
-    #[test_case("/key/inner_key", Some(&testing_vec![
+    #[test_case("/key/inner_key", Some(&rust_type_vec![
         1,
         "2"
     ]))]
@@ -259,9 +259,9 @@ mod primitive_type_tests {
     #[test_case("/key/inner_key/a", None)]
     #[test_case("/key/inner_key/2", None)]
     fn test_get_fragment(fragment: &str, expected_value: Option<&RustType>) {
-        let external_map = testing_map![
-            "key" => testing_map![
-                "inner_key" => testing_vec![
+        let external_map = rust_type_map![
+            "key" => rust_type_map![
+                "inner_key" => rust_type_vec![
                     1,
                     "2"
                 ],

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
-macro_rules! testing_map {
+macro_rules! rust_type_map {
     ($($k:expr => $v: expr),*,) => {{
-        testing_map![$($k => $v),*]
+        rust_type_map![$($k => $v),*]
     }};
     ($($k: expr => $v: expr),*) => {{
         use $crate::RustType;
@@ -16,9 +16,9 @@ macro_rules! testing_map {
 }
 
 #[macro_export]
-macro_rules! testing_vec {
+macro_rules! rust_type_vec {
     ($($item: expr),*,) => {{
-        testing_vec![$($item),*]
+        rust_type_vec![$($item),*]
     }};
     ($($item: expr),*) => {{
         use $crate::RustType;


### PR DESCRIPTION
The goal of this PR is mostly related to naming unification.
As the _default_ type provided by this crate is `RustType` the macros have been renamed from `testing_*` into `rust_type_*`