### PR TITLE
Simplify lifetimes and relax returned Iterators

### DIFF
--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -49,16 +49,16 @@ where
     T: 'json + JsonType<T>,
 {
     #[inline]
-    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json> {
+    fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         Box::new(self.items().map(|(key, _)| key))
     }
 
     #[inline]
-    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &T> + 'json> {
+    fn values(&'json self) -> Box<dyn Iterator<Item = &T> + 'json> {
         Box::new(self.items().map(|(_, value)| value))
     }
 
-    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &T)> + 'json>;
+    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &T)> + 'json>;
 }
 
 // This trait allows us to have a 1:1 mapping with serde_json, generally used by rust libraries
@@ -68,7 +68,7 @@ pub trait JsonType<T>: Debug + Sync + Send
 where
     T: JsonType<T>,
 {
-    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &T> + 'json>>;
+    fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &T> + 'json>>;
     fn as_boolean(&self) -> Option<bool>;
     fn as_integer(&self) -> Option<i128>;
     fn as_null(&self) -> Option<()>;

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -46,21 +46,15 @@ impl EnumJsonType {
 
 pub trait JsonMapTrait<'json, T>
 where
-    T: JsonType<T>,
+    T: 'json + JsonType<T>,
 {
     #[inline]
-    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json>
-    where
-        T: 'json,
-    {
+    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json> {
         Box::new(self.items().map(|(key, _)| key))
     }
 
     #[inline]
-    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &T> + 'json>
-    where
-        T: 'json,
-    {
+    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &T> + 'json> {
         Box::new(self.items().map(|(_, value)| value))
     }
 

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -61,7 +61,7 @@ impl From<Vec<RustType>> for RustType {
 }
 
 impl JsonType<RustType> for RustType {
-    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
+    fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
         match self {
             RustType::List(v) => Some(Box::new(v.iter())),
             _ => None,
@@ -138,7 +138,7 @@ impl JsonType<RustType> for RustType {
 
 impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
     #[inline]
-    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &RustType)> + 'json> {
+    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &RustType)> + 'json> {
         if let RustType::Object(hash_map) = self.deref() {
             Box::new(hash_map.iter().map(|(k, v)| (k.as_str(), v)))
         } else {

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -4,26 +4,26 @@ use std::ops::Index;
 
 impl<'json> JsonMapTrait<'json, json::JsonValue> for JsonMap<'json, json::JsonValue> {
     #[inline]
-    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json> {
+    fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         // TODO: remove .collect().into_iter() once https://github.com/maciejhirsz/json-rust/pull/156 is merged
         Box::new(self.entries().map(|(key, _)| key).collect::<Vec<_>>().into_iter())
     }
 
     #[inline]
-    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &json::JsonValue> + 'json> {
+    fn values(&'json self) -> Box<dyn Iterator<Item = &json::JsonValue> + 'json> {
         // TODO: remove .collect().into_iter() once https://github.com/maciejhirsz/json-rust/pull/156 is merged
         Box::new(self.entries().map(|(_, value)| value).collect::<Vec<_>>().into_iter())
     }
 
     #[inline]
-    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &json::JsonValue)> + 'json> {
+    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &json::JsonValue)> + 'json> {
         // TODO: remove .collect().into_iter() once https://github.com/maciejhirsz/json-rust/pull/156 is merged
         Box::new(self.entries().collect::<Vec<_>>().into_iter())
     }
 }
 
 impl JsonType<json::JsonValue> for json::JsonValue {
-    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
+    fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
         if self.is_array() {
             Some(Box::new(self.members()))
         } else {

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -3,7 +3,7 @@ use serde_json;
 
 impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json::Value> {
     #[inline]
-    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json> {
+    fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.keys().map(AsRef::as_ref))
         } else {
@@ -15,7 +15,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 
     #[inline]
-    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &serde_json::Value> + 'json> {
+    fn values(&'json self) -> Box<dyn Iterator<Item = &serde_json::Value> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.values())
         } else {
@@ -27,7 +27,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 
     #[inline]
-    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &serde_json::Value)> + 'json> {
+    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &serde_json::Value)> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.iter().map(|(k, v)| (k.as_ref(), v)))
         } else {
@@ -40,7 +40,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
 }
 
 impl JsonType<serde_json::Value> for serde_json::Value {
-    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
+    fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_array() {
             Some(Box::new(vec.iter()))
         } else {

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -3,7 +3,7 @@ use serde_yaml;
 
 impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml::Value> {
     #[inline]
-    fn keys(&'json self) -> Box<dyn ExactSizeIterator<Item = &str> + 'json> {
+    fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(key, _)| (key.as_str().unwrap())))
         } else {
@@ -15,7 +15,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 
     #[inline]
-    fn values(&'json self) -> Box<dyn ExactSizeIterator<Item = &serde_yaml::Value> + 'json> {
+    fn values(&'json self) -> Box<dyn Iterator<Item = &serde_yaml::Value> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(_, value)| value))
         } else {
@@ -27,7 +27,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 
     #[inline]
-    fn items(&'json self) -> Box<dyn ExactSizeIterator<Item = (&str, &serde_yaml::Value)> + 'json> {
+    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &serde_yaml::Value)> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(key, value)| (key.as_str().unwrap(), value)))
         } else {
@@ -40,7 +40,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
 }
 
 impl JsonType<serde_yaml::Value> for serde_yaml::Value {
-    fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
+    fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_sequence() {
             Some(Box::new(vec.iter()))
         } else {


### PR DESCRIPTION
The goal of this PR is to simplify lifetimes definitions (into `JsonMapTrait`) and to relax `Iterator` types.

The idea of moving from `ExactSizeIterator` to `Iterator` allows an easier integration of not-rust native types (ie. types provided by https://github.com/PyO3/pyo3)