### PR TITLE
Add pyo3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-rust: stable
 
 env:
   global:
@@ -13,6 +12,7 @@ matrix:
   - os: linux
     dist: xenial
     env: MAKE_TARGET=coverage
+    rust: nightly  # Running on nightly to ensure that all the traits are actually tested
     addons:
       apt:
         packages:
@@ -24,12 +24,20 @@ matrix:
         - g++
   - os: linux
     dist: xenial
-    env: MAKE_TARGET=test
+    rust: stable
+    env: MAKE_TARGET=test-all-flavours
+  - os: linux
+    dist: xenial
+    rust: nightly
+    env: MAKE_TARGET=test-all-flavours
   - os: linux
     dist: xenial
     env: MAKE_TARGET=doc
+    rust: stable
   - os: linux
     dist: xenial
+    rust: nightly-2019-07-25  # Running on nighly to ensure that all the codebase are checked by the linters)
+                              # Using an "older" nightly version due to difficulties into building rustfmt on latest nighyly
     env: MAKE_TARGET=lint
   allow_failures:
   - env: MAKE_TARGET=lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ default = []
 trait_json = ["json"]
 trait_serde_json = ["serde_json"]
 trait_serde_yaml = ["serde_yaml"]
+trait_pyo3 = ["pyo3"]
 
 [dev-dependencies]
 lazy_static = "1"
@@ -33,6 +34,7 @@ test-case-derive = "0"
 
 [dependencies]
 json = { version = "0", optional = true }
+pyo3 = { version = "0", optional = true }
 serde_json = { version = "1", optional = true }
 serde_yaml = { version = "0", optional = true }
 strum = "0"
@@ -41,4 +43,4 @@ unreachable = "1"
 
 [patch.crates-io]
 # TODO: Remove patch once https://github.com/synek317/test-case-derive/pull/5 is merged
-test-case-derive = { git = "https://github.com/macisamuele/test-case-derive", branch = "maci-allow-build-on-stable"}
+test-case-derive = { git = "https://github.com/macisamuele/test-case-derive", branch = "maci-allow-build-on-stable" }

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ clippy:
 	touch src/lib.rs   # touch a file of the rust project to "force" cargo to recompile it so clippy will actually run
 	cargo +${RUST_TOOLCHAIN} clippy --all-targets ${CARGO_ARGS} -- -D clippy::pedantic -D clippy::nursery
 
+.PHONY: clippy-all-flavours
+clippy-all-flavours:
+	$(call call_all_features,clippy)
+
 .PHONY: pre-commit
 pre-commit: venv
 	./venv/bin/pre-commit run --all-files

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ endif
 define call_all_features
 set -eu && \
     ( \
-        for cargo_args in "" --no-default-features --all-features; do CARGO_ARGS="${CARGO_ARGS} $${cargo_args}" ${MAKE} $(1); done; \
-        for cargo_args in $$(bash ${CURDIR}/scripts/cargo-features.sh); do CARGO_ARGS="${CARGO_ARGS} --features $${cargo_args}" ${MAKE} $(1); done \
+        for cargo_args in "" --no-default-features; do CARGO_ARGS="${CARGO_ARGS} $${cargo_args}" ${MAKE} $(1); done; \
+        for feature in $$(bash ${CURDIR}/scripts/cargo-features.sh); do CARGO_ARGS="${CARGO_ARGS} --features '$${feature}'" ${MAKE} $(1); done; \
+        CARGO_ARGS="${CARGO_ARGS} --features '$$(bash ${CURDIR}/scripts/cargo-features.sh)'" ${MAKE} $(1); \
     )
 endef
 

--- a/features-enabled-on-nightly-only
+++ b/features-enabled-on-nightly-only
@@ -1,0 +1,3 @@
+# Track on this file all the traits that are available only on nightly rust.
+# By doing so we can ensure that we do test them only on the correct environment
+trait_pyo3

--- a/scripts/cargo-features.sh
+++ b/scripts/cargo-features.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail -o posix -o functrace
 
-cargo metadata --format-version 1 | python -c "$(cat <<EOF
+if echo "${RUST_TOOLCHAIN:-stable}" | grep --quiet "^nightly" ; then
+    features_to_ignore=""
+else
+    features_to_ignore="$(grep -v '#' features-enabled-on-nightly-only)"
+    echo "Ignoring the following features as they are available only on nightly rust: ${features_to_ignore}" > /dev/stderr
+fi
+
+cargo metadata --format-version 1 | FEATURES_TO_IGNORE=${features_to_ignore} python -c "$(cat <<EOF
 from __future__ import print_function
+import os
 import json
 import sys
 
+features_to_ignore = os.environ['FEATURES_TO_IGNORE'].split()
 metadata = json.load(sys.stdin)
 package_metadata = next(item for item in metadata['packages'] if item['id'] == metadata['resolve']['root'])
-print(' '.join(filter(lambda item: item != 'default', package_metadata['features'])))
+print(' '.join(filter(lambda item: item != 'default' and item not in features_to_ignore, package_metadata['features'])))
 EOF
 )"

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -1,0 +1,403 @@
+use crate::{JsonMap, JsonMapTrait, JsonType};
+#[cfg(test)]
+use pyo3::Python;
+use pyo3::{
+    types::{PyAny, PyDict, PySequence},
+    ObjectProtocol, PyTryInto,
+};
+use std::{convert::TryInto, ops::Deref};
+
+impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
+    fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
+        match PyTryInto::<PyDict>::try_into(self.deref()) {
+            Ok(python_dict) => Box::new(python_dict.iter().filter_map(|(k, _)| k.as_string())),
+            Err(_) => Box::new(Vec::with_capacity(0).into_iter()),
+        }
+    }
+
+    fn values(&'json self) -> Box<dyn Iterator<Item = &PyAny> + 'json> {
+        match PyTryInto::<PyDict>::try_into(self.deref()) {
+            Ok(python_dict) => Box::new(python_dict.iter().map(|(_, v)| v)),
+            Err(_) => Box::new(Vec::with_capacity(0).into_iter()),
+        }
+    }
+
+    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &PyAny)> + 'json> {
+        match PyTryInto::<PyDict>::try_into(self.deref()) {
+            Ok(python_dict) => Box::new(python_dict.iter().filter_map(|(k, v)| k.as_string().and_then(|k_string| Some((k_string, v))).or(None))),
+            Err(_) => Box::new(Vec::with_capacity(0).into_iter()),
+        }
+    }
+}
+
+impl JsonType<PyAny> for PyAny {
+    fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
+        match PyTryInto::<PySequence>::try_into(self) {
+            Err(_) => None,
+            Ok(py_sequence) => match py_sequence.iter() {
+                Err(_) => None,
+                Ok(iterator) => {
+                    if self.is_string() {
+                        None
+                    } else {
+                        Some(Box::new(iterator.filter_map(Result::ok)))
+                    }
+                }
+            },
+        }
+    }
+
+    fn as_boolean(&self) -> Option<bool> {
+        self.extract().ok()
+    }
+
+    fn as_integer(&self) -> Option<i128> {
+        self.extract().ok().and_then(|value| {
+            // In python `assert isinstance(True, int) is True` is correct
+            // So if we're able to convert the instance to a i128 instance then we need
+            // to verify that we did not start from a boolean instance
+            if self.is_boolean() {
+                None
+            } else {
+                Some(value)
+            }
+        })
+    }
+
+    fn as_null(&self) -> Option<()> {
+        if self.is_none() {
+            Some(())
+        } else {
+            None
+        }
+    }
+
+    fn as_number(&self) -> Option<f64> {
+        self.extract().ok().and_then(|value| {
+            // pyo3 is able to convert a boolean value into a f64 instance
+            // So if we're converted the PyAny instance into a f64 instance then we need
+            // to verify that we did not start from a boolean instance
+            if self.is_boolean() {
+                None
+            } else {
+                Some(value)
+            }
+        })
+    }
+
+    fn as_object(&self) -> Option<JsonMap<Self>>
+    where
+        for<'json> JsonMap<'json, Self>: JsonMapTrait<'json, Self>,
+    {
+        PyTryInto::<PyDict>::try_into(self).ok().and_then(|_| Some(JsonMap::new(self)))
+    }
+
+    fn as_string(&self) -> Option<&str> {
+        self.extract().ok()
+    }
+
+    fn get_attribute(&self, attribute_name: &str) -> Option<&Self> {
+        PyTryInto::<PyDict>::try_into(self).ok().and_then(|python_dict| python_dict.get_item(attribute_name))
+    }
+
+    fn get_index(&self, index: usize) -> Option<&Self> {
+        TryInto::<isize>::try_into(index)
+            .ok()
+            .and_then(|idx| PyTryInto::<PySequence>::try_into(self).ok().and_then(|python_sequence| python_sequence.get_item(idx).ok()))
+    }
+}
+
+#[cfg(test)]
+fn perform_python_check(python_code_string: &str, check: impl Fn(&PyAny) -> ()) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    check(py.eval(python_code_string, None, None).unwrap())
+}
+
+#[cfg(test)]
+mod tests_json_map_trait {
+    use crate::{json_type::JsonMap, traits::_pyo3::perform_python_check, JsonMapTrait};
+    use std::collections::HashSet;
+
+    lazy_static! {
+        static ref PYTHON_TESTING_MAP_STR: &'static str = "{'k1': 'v1', 'k2': 'v2'}";
+    }
+
+    #[test]
+    fn keys() {
+        perform_python_check(&PYTHON_TESTING_MAP_STR, |python_object_ref| {
+            // HashSet needed as python does not guarantee ordering of keys, or anyway we should not care about ordering
+            assert_eq!(
+                JsonMap::new(python_object_ref).keys().collect::<HashSet<_>>(),
+                vec!["k1", "k2"].into_iter().collect::<HashSet<_>>()
+            );
+        });
+    }
+
+    #[test]
+    fn values() {
+        perform_python_check(&PYTHON_TESTING_MAP_STR, |python_object_ref| {
+            // HashSet needed as python does not guarantee ordering of keys, or anyway we should not care about ordering
+            assert_eq!(
+                JsonMap::new(python_object_ref).values().map(|value| format!("{}", value)).collect::<HashSet<_>>(),
+                vec!["v1".to_string(), "v2".to_string()].into_iter().collect::<HashSet<_>>()
+            );
+        });
+    }
+
+    #[test]
+    fn items() {
+        perform_python_check(&PYTHON_TESTING_MAP_STR, |python_object_ref| {
+            // HashSet needed as python does not guarantee ordering of keys, or anyway we should not care about ordering
+            assert_eq!(
+                JsonMap::new(python_object_ref)
+                    .items()
+                    .map(|(key, value)| (key, format!("{}", value)))
+                    .collect::<HashSet<_>>(),
+                vec![("k1", "v1".to_string()), ("k2", "v2".to_string()),].into_iter().collect::<HashSet<_>>()
+            );
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests_primitive_type_trait {
+    use crate::{
+        json_type::{EnumJsonType, JsonType},
+        traits::_pyo3::perform_python_check,
+    };
+    use test_case_derive::test_case;
+
+    #[test_case("[]", EnumJsonType::Array)]
+    #[test_case("True", EnumJsonType::Boolean)]
+    #[test_case("1", EnumJsonType::Integer)]
+    #[test_case("None", EnumJsonType::Null)]
+    #[test_case("1.2", EnumJsonType::Number)]
+    #[test_case("{'prop': 'value'}", EnumJsonType::Object)]
+    #[test_case("'string'", EnumJsonType::String)]
+    fn test_primitive_type(python_code_string: &str, expected_value: EnumJsonType) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::primitive_type(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("{'present': 1}", "present", Some(1))]
+    #[test_case("{'present': 1}", "not-present", None)]
+    fn test_get_attribute(python_code_string: &str, attribute_name: &str, expected_value: Option<i128>) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(
+                JsonType::get_attribute(python_object_ref, attribute_name).and_then(|value| value.as_integer()),
+                expected_value
+            );
+        })
+    }
+
+    #[test_case("[0, 1, 2]", 1, Some(1))]
+    #[test_case("[0, 1, 2]", 4, None)]
+    fn test_get_index(python_code_string: &str, index: usize, expected_value: Option<i128>) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::get_index(python_object_ref, index).and_then(|value| value.as_integer()), expected_value);
+        })
+    }
+
+    #[test_case("{'present': 1}", "present", true)]
+    #[test_case("{'present': 1}", "not-present", false)]
+    #[test_case("[1, 2, 3]", "not-present", false)]
+    fn test_has_attribute(python_code_string: &str, attr_name: &str, expected_value: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::has_attribute(python_object_ref, attr_name), expected_value);
+        })
+    }
+
+    #[test_case("[0, 1, 2]", true)]
+    #[test_case("True", false)]
+    #[test_case("1", false)]
+    #[test_case("None", false)]
+    #[test_case("1.2", false)]
+    #[test_case("{'key': 'value'}", false)]
+    #[test_case("'string'", false)]
+    fn test_is_array(python_code_string: &str, expected_value: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::is_array(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("[0, 1, 2]", false)]
+    #[test_case("True", true)]
+    #[test_case("1", false)]
+    #[test_case("None", false)]
+    #[test_case("1.2", false)]
+    #[test_case("{'key': 'value'}", false)]
+    #[test_case("'string'", false)]
+    fn test_is_boolean(python_code_string: &str, expected_value: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::is_boolean(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("[0, 1, 2]", false)]
+    #[test_case("True", false)]
+    #[test_case("1", true)]
+    #[test_case("None", false)]
+    #[test_case("1.2", false)]
+    #[test_case("{'key': 'value'}", false)]
+    #[test_case("'string'", false)]
+    fn test_is_integer(python_code_string: &str, expected_value: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::is_integer(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("[0, 1, 2]", false)]
+    #[test_case("True", false)]
+    #[test_case("1", false)]
+    #[test_case("None", true)]
+    #[test_case("1.2", false)]
+    #[test_case("{'key': 'value'}", false)]
+    #[test_case("'string'", false)]
+    fn test_is_null(python_code_string: &str, expected_value: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::is_null(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("[0, 1, 2]", false)]
+    #[test_case("True", false)]
+    #[test_case("1", true)]
+    #[test_case("None", false)]
+    #[test_case("1.2", true)]
+    #[test_case("{'key': 'value'}", false)]
+    #[test_case("'string'", false)]
+    fn test_is_number(python_code_string: &str, expected_value: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::is_number(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("[0, 1, 2]", false)]
+    #[test_case("True", false)]
+    #[test_case("1", false)]
+    #[test_case("None", false)]
+    #[test_case("1.2", false)]
+    #[test_case("{'key': 'value'}", true)]
+    #[test_case("'string'", false)]
+    fn test_is_object(python_code_string: &str, expected_value: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::is_object(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("[0, 1, 2]", false)]
+    #[test_case("True", false)]
+    #[test_case("1", false)]
+    #[test_case("None", false)]
+    #[test_case("1.2", false)]
+    #[test_case("{'key': 'value'}", false)]
+    #[test_case("'string'", true)]
+    fn test_is_string(python_code_string: &str, expected_value: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::is_string(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("[1]", true)]
+    #[test_case("[1, 'a']", true)]
+    #[test_case("None", false)]
+    fn test_as_array(python_code_string: &str, is_some: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::as_array(python_object_ref).is_some(), is_some);
+        })
+    }
+
+    #[test_case("True", Some(true))]
+    #[test_case("False", Some(false))]
+    #[test_case("1", None)]
+    fn test_as_boolean(python_code_string: &str, expected_value: Option<bool>) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::as_boolean(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("1", Some(1))]
+    #[test_case("1.2", None)]
+    #[test_case("'1'", None)]
+    fn test_as_integer(python_code_string: &str, expected_value: Option<i128>) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::as_integer(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("None", Some(()))]
+    #[test_case("'1'", None)]
+    fn test_as_null(python_code_string: &str, expected_value: Option<()>) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::as_null(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("1", Some(1_f64))]
+    #[test_case("1.2", Some(1.2))]
+    #[test_case("'1'", None)]
+    fn test_as_number(python_code_string: &str, expected_value: Option<f64>) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::as_number(python_object_ref), expected_value);
+        })
+    }
+
+    #[test_case("1", false)]
+    #[test_case("1.2", false)]
+    #[test_case("{'1': 1}", true)]
+    fn test_as_object(python_code_string: &str, is_some: bool) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::as_object(python_object_ref).is_some(), is_some);
+        })
+    }
+
+    #[test_case("1", None)]
+    #[test_case("1.2", None)]
+    #[test_case("'1'", Some("1"))]
+    fn test_as_string(python_code_string: &str, expected_value: Option<&str>) {
+        perform_python_check(python_code_string, |python_object_ref| {
+            assert_eq!(JsonType::as_string(python_object_ref), expected_value);
+        })
+    }
+}
+
+#[cfg(test)]
+mod json_map_tests {
+    use crate::{traits::_pyo3::perform_python_check, JsonMapTrait, JsonType};
+
+    lazy_static! {
+        static ref PYTHON_TESTING_MAP_STR: &'static str = "{'key1': {'key2': 1}}";
+    }
+
+    #[test]
+    fn test_keys() {
+        perform_python_check(&PYTHON_TESTING_MAP_STR, |python_object_ref| {
+            let key1 = python_object_ref.get_attribute("key1").unwrap();
+            assert_eq!(JsonType::as_object(key1).unwrap().keys().map(|k| { k }).collect::<Vec<_>>(), vec![String::from("key2")],);
+        });
+    }
+
+    #[test]
+    fn test_values() {
+        perform_python_check(&PYTHON_TESTING_MAP_STR, |python_object_ref| {
+            let key1 = python_object_ref.get_attribute("key1").unwrap();
+            assert_eq!(
+                JsonType::as_object(key1).unwrap().values().map(|v| { format!("{:?}", v) }).collect::<Vec<_>>(),
+                vec![1.to_string()],
+            );
+        });
+    }
+
+    #[test]
+    fn test_items() {
+        perform_python_check(&PYTHON_TESTING_MAP_STR, |python_object_ref| {
+            let key1 = python_object_ref.get_attribute("key1").unwrap();
+            assert_eq!(
+                JsonType::as_object(key1).unwrap().items().map(|(k, v)| { format!("{} -> {:?}", k, v) }).collect::<Vec<_>>(),
+                vec!["key2 -> 1".to_string()],
+            );
+        });
+    }
+}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "trait_json")]
 pub mod _json;
+#[cfg(feature = "trait_pyo3")]
+pub mod _pyo3;
 #[cfg(feature = "trait_serde_json")]
 pub mod _serde_json;
 #[cfg(feature = "trait_serde_yaml")]


### PR DESCRIPTION
The goal of this PR is to implement `JsonType` trait for `PyAny` object defined by [PyO3](https://github.com/PyO3/pyo3).
By doing this we allow the usage of the `JsonType` trait by python bindings built on top of [PyO3](https://github.com/PyO3/pyo3), avoiding useless JSON serialisation/deserialisation.

As PyO3 is compatible with nightly rust only, I've modified the travis configurations to allow testing on stable and nightly (identification of features list keeps into account the rust compiler)