### PR TITLE
Coverage via grcov instead of kcov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /**/*.rs.bk
 /.coverage/
 /.idea/
-/.lcov.info
 /Cargo.lock
 /codecov.bash
 /target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,6 @@ matrix:
     dist: xenial
     env: MAKE_TARGET=coverage
     rust: nightly  # Running on nightly to ensure that all the traits are actually tested
-    addons:
-      apt:
-        packages:
-        - libcurl4-openssl-dev
-        - libelf-dev
-        - libdw-dev
-        - binutils-dev
-        - libiberty-dev
-        - g++
   - os: linux
     dist: xenial
     rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ cache:
   timeout: 3600
   directories:
   - ${HOME}/.cache/pre-commit
-  - ${KCOV_DIR}
   - ${CODECOV_DIR}
   - ${HOME}/.cargo/
   - ${TRAVIS_BUILD_DIR}/target

--- a/scripts/cargo-features.sh
+++ b/scripts/cargo-features.sh
@@ -4,7 +4,7 @@ set -euo pipefail -o posix -o functrace
 if echo "${RUST_TOOLCHAIN:-stable}" | grep --quiet "^nightly" ; then
     features_to_ignore=""
 else
-    features_to_ignore="$(grep -v '#' features-enabled-on-nightly-only)"
+    features_to_ignore="$(grep -v '#' features-enabled-on-nightly-only 2> /dev/null || true)"
     echo "Ignoring the following features as they are available only on nightly rust: ${features_to_ignore}" > /dev/stderr
 fi
 

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -8,5 +8,4 @@ rustup --version
 rustup show
 rustc --version --verbose
 cargo --version --verbose
-if [[ ${MAKE_TARGET} = "coverage" ]]; then cargo kcov --version; fi
-if [[ ${MAKE_TARGET} = "coverage" ]]; then kcov --version; fi
+if [[ ${MAKE_TARGET} = "coverage" ]]; then grcov --version; fi


### PR DESCRIPTION
Changing the tooling used to track coverage as grcov has:
 * better interaction on multiple OSs (no need of docker to capture coverage on Mac OS)
 * maintained by mozilla team (so hopefully it will get tons of new features)
 * extremely easy and fast to install
