### PR TITLE
Remove needless collect to Vec in JsonMapTrait<'json, json::JsonValue>

### DIFF
--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -5,20 +5,17 @@ use std::ops::Index;
 impl<'json> JsonMapTrait<'json, json::JsonValue> for JsonMap<'json, json::JsonValue> {
     #[inline]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
-        // TODO: remove .collect().into_iter() once https://github.com/maciejhirsz/json-rust/pull/156 is merged
-        Box::new(self.entries().map(|(key, _)| key).collect::<Vec<_>>().into_iter())
+        Box::new(self.entries().map(|(key, _)| key))
     }
 
     #[inline]
     fn values(&'json self) -> Box<dyn Iterator<Item = &json::JsonValue> + 'json> {
-        // TODO: remove .collect().into_iter() once https://github.com/maciejhirsz/json-rust/pull/156 is merged
-        Box::new(self.entries().map(|(_, value)| value).collect::<Vec<_>>().into_iter())
+        Box::new(self.entries().map(|(_, value)| value))
     }
 
     #[inline]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &json::JsonValue)> + 'json> {
-        // TODO: remove .collect().into_iter() once https://github.com/maciejhirsz/json-rust/pull/156 is merged
-        Box::new(self.entries().collect::<Vec<_>>().into_iter())
+        Box::new(self.entries())
     }
 }
 


### PR DESCRIPTION
PR #7 relaxed the constraint associated to the iterator types returned by `JsonMapTrait`.
Thanks to it we don't actually need to have `.collect().into_iter()` which actually implies:
 * needless memory allocation
 * processing time (to duplicate materialise the items into the new memory location)

Even if we would not have relaxed the iterator type we might have had the possibility to remove it as `json>=0.11.14` does return `ExactSizeIterator` ;)