### PR TITLE
Enable tests on OSX and Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
 
 matrix:
   include:
-  # TODO: add osx and windows testing environments
   - os: linux
     dist: xenial
     env: MAKE_TARGET=coverage
@@ -21,17 +20,31 @@ matrix:
     dist: xenial
     rust: nightly
     env: MAKE_TARGET=test-all-flavours
+  - os: osx
+    rust: stable
+    env: MAKE_TARGET=test-all-flavours
+  - os: osx
+    rust: nightly
+    env: MAKE_TARGET=test-all-flavours
+  - os: windows
+    rust: stable
+    env: MAKE_TARGET=test-all-flavours
+#  - os: windows  # TODO: run tests on nighly to ensure that pyo3 feature works on windows as well
+#    rust: nightly
+#    env: MAKE_TARGET=test-all-flavours PYTHON_SYS_EXECUTABLE=/C/Python37/python.exe
   - os: linux
     dist: xenial
     env: MAKE_TARGET=doc
     rust: stable
   - os: linux
     dist: xenial
-    rust: nightly-2019-07-25  # Running on nighly to ensure that all the codebase are checked by the linters)
+    rust: nightly-2019-07-19  # Running on nighly to ensure that all the codebase are checked by the linters)
                               # Using an "older" nightly version due to difficulties into building rustfmt on latest nighyly
     env: MAKE_TARGET=lint
   allow_failures:
   - env: MAKE_TARGET=lint
+  - os: osx
+  - os: windows
 
 install:
 - bash scripts/travis/install.sh
@@ -49,6 +62,7 @@ cache:
   - ${CODECOV_DIR}
   - ${HOME}/.cargo/
   - ${TRAVIS_BUILD_DIR}/target
+  - /C/ProgramData/chocolatey
 
 # notifications:
 #   email: false

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -6,7 +6,14 @@ set -euo pipefail -o posix -o functrace
 install_make() {
   # Install make on windows
   if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
-      choco install make
+    choco install make
+  fi
+}
+
+install_python() {
+  # Install python on windows
+  if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
+    choco install python --version "${PYTHON_VERSION:-3.7.4}"
   fi
 }
 
@@ -30,22 +37,22 @@ install_lint_tools() {
   if [[ ${MAKE_TARGET} == "lint" ]]; then
     pip install --no-cache-dir --user pre-commit
     if rustup component list --toolchain="${TRAVIS_RUST_VERSION}" | grep installed | grep -q rustfmt; then
-        echo "# Skipping rustfmt install as already present"
+      echo "# Skipping rustfmt install as already present"
     else
-        rustup component add rustfmt --toolchain="${TRAVIS_RUST_VERSION}"
+      rustup component add rustfmt --toolchain="${TRAVIS_RUST_VERSION}"
     fi
     if rustup component list --toolchain="${TRAVIS_RUST_VERSION}" | grep installed | grep -q clippy; then
-        echo "# Skipping clippy install as already present"
+      echo "# Skipping clippy install as already present"
     else
-        # Workaround in case clippy is not available in the current nightly release (https://github.com/rust-lang/rust-clippy#travis-ci)
-        rustup component add clippy --toolchain="${TRAVIS_RUST_VERSION}" || cargo +"${TRAVIS_RUST_VERSION}" install --git https://github.com/rust-lang/rust-clippy/ --force clippy
+      # Workaround in case clippy is not available in the current nightly release (https://github.com/rust-lang/rust-clippy#travis-ci)
+      rustup component add clippy --toolchain="${TRAVIS_RUST_VERSION}" || cargo +"${TRAVIS_RUST_VERSION}" install --git https://github.com/rust-lang/rust-clippy/ --force clippy
     fi
-
   else
     echo "# Skipping lint-tools install as target is not coverage" > /dev/stderr
   fi
 }
 
 install_make
+install_python
 install_kcov
 install_lint_tools


### PR DESCRIPTION
Run OSX and Windows tests on travis.
The new added tests are not considered mandatory yet, but they won't be allowed to fail in the next future.

**NOTE**: Windows tests are still failing if trying to test `trait_pyo3` feature. This will be addressed in a following PR