### PR TITLE
Fix coverage (change in grcov)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ coverage: clean-coverage ${CODECOV_DIR}/codecov.bash
 		--source-dir ${CURDIR} \
 		--output-type lcov \
 		--llvm \
-		--ignore-dir "/*" \
+		--ignore "/*" \
 		--ignore-not-existing \
 		--output-file ${CURDIR}/.coverage/lcov.info
 	@[ "${TRAVIS}" = "true" ] && \

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -8,4 +8,4 @@ rustup --version
 rustup show
 rustc --version --verbose
 cargo --version --verbose
-if [[ ${MAKE_TARGET} = "coverage" ]]; then grcov --version; fi
+if [[ ${MAKE_TARGET} == "coverage" ]]; then grcov --version; fi

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -17,18 +17,11 @@ install_python() {
   fi
 }
 
-install_kcov() {
+install_grcov() {
   if [[ ${MAKE_TARGET} == "coverage" ]]; then
-    GITHUB_GRCOV="https://api.github.com/repos/mozilla/grcov/releases/latest"
-    GRCOV_DEFAULT_VERSION="v0.5.1"
-    if [[ ${TRAVIS_OS_NAME} == "windows" ]]; then OS_NAME="win"; else OS_NAME=${TRAVIS_OS_NAME}; fi
-
-    # Usage: download and install the latest kcov version by default.
-    # Fall back to ${KCOV_DEFAULT_VERSION} from the kcov archive if the latest is unavailable.
-    GRCOV_VERSION=$(curl --silent --show-error --fail ${GITHUB_GRCOV} | jq -Mr .tag_name || echo)
-    GRCOV_VERSION=${GRCOV_VERSION:-${GRCOV_DEFAULT_VERSION}}
-    GRCOV_TAR_BZ2="https://github.com/mozilla/grcov/releases/download/${GRCOV_VERSION}/grcov-${OS_NAME}-x86_64.tar.bz2"
-    curl -L --retry 3 "${GRCOV_TAR_BZ2}" | tar xjf - -C "${CARGO_HOME:-${HOME}/.cargo/bin}"
+    if ! command -v grcov @> /dev/null; then
+      cargo install grcov
+    fi
   fi
 }
 
@@ -54,5 +47,5 @@ install_lint_tools() {
 
 install_make
 install_python
-install_kcov
+install_grcov
 install_lint_tools


### PR DESCRIPTION
A change in grcov v0.5.5 leads to coverage failure (`--ignore-dir` has been renamed into `--ignore`).

This PR does also ensures that grcov is installed via travis scripts so we can have a proper version reporting.