### PR TITLE
add must use

### DIFF
--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -15,6 +15,7 @@ pub enum EnumJsonType {
 }
 
 impl EnumJsonType {
+    #[must_use]
     pub fn from_type(type_string: &str) -> Option<Self>
     where
         Self: Sized,
@@ -31,6 +32,7 @@ impl EnumJsonType {
         }
     }
 
+    #[must_use]
     pub fn to_type(&self) -> &str {
         match self {
             Self::Array => "array",
@@ -49,15 +51,18 @@ where
     T: 'json + JsonType<T>,
 {
     #[inline]
+    #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         Box::new(self.items().map(|(key, _)| key))
     }
 
     #[inline]
+    #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &T> + 'json> {
         Box::new(self.items().map(|(_, value)| value))
     }
 
+    #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &T)> + 'json>;
 }
 
@@ -174,6 +179,7 @@ where
 {
     type Target = T;
 
+    #[must_use]
     fn deref(&self) -> &Self::Target {
         self.0
     }

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -50,13 +50,11 @@ pub trait JsonMapTrait<'json, T>
 where
     T: 'json + JsonType<T>,
 {
-    #[inline]
     #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         Box::new(self.items().map(|(key, _)| key))
     }
 
-    #[inline]
     #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &T> + 'json> {
         Box::new(self.items().map(|(_, value)| value))
@@ -86,32 +84,26 @@ where
     fn get_attribute(&self, attribute_name: &str) -> Option<&T>;
     fn get_index(&self, index: usize) -> Option<&T>;
 
-    #[inline]
     fn is_array(&self) -> bool {
         self.as_array().is_some()
     }
 
-    #[inline]
     fn is_boolean(&self) -> bool {
         self.as_boolean().is_some()
     }
 
-    #[inline]
     fn is_integer(&self) -> bool {
         self.as_integer().is_some()
     }
 
-    #[inline]
     fn is_null(&self) -> bool {
         self.as_null().is_some()
     }
 
-    #[inline]
     fn is_number(&self) -> bool {
         self.as_number().is_some()
     }
 
-    #[inline]
     fn is_object(&self) -> bool
     where
         for<'json> JsonMap<'json, T>: JsonMapTrait<'json, T>,
@@ -119,17 +111,14 @@ where
         self.as_object().is_some()
     }
 
-    #[inline]
     fn is_string(&self) -> bool {
         self.as_string().is_some()
     }
 
-    #[inline]
     fn has_attribute(&self, attribute_name: &str) -> bool {
         self.get_attribute(attribute_name).is_some()
     }
 
-    #[inline]
     fn primitive_type(&self) -> EnumJsonType
     where
         for<'json> JsonMap<'json, T>: JsonMapTrait<'json, T>,
@@ -167,7 +156,6 @@ impl<'json, T> JsonMap<'json, T>
 where
     T: JsonType<T>,
 {
-    #[inline]
     pub fn new(object: &'json T) -> Self {
         Self(object)
     }

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -155,7 +155,6 @@ impl JsonType<RustType> for RustType {
 }
 
 impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
-    #[inline]
     #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &RustType)> + 'json> {
         if let RustType::Object(hash_map) = self.deref() {

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -13,54 +13,63 @@ pub enum RustType {
 }
 
 impl Default for RustType {
+    #[must_use]
     fn default() -> Self {
         Self::Null
     }
 }
 
 impl From<()> for RustType {
+    #[must_use]
     fn from(_: ()) -> Self {
         Self::Null
     }
 }
 
 impl From<bool> for RustType {
+    #[must_use]
     fn from(value: bool) -> Self {
         Self::Boolean(value)
     }
 }
 
 impl From<&str> for RustType {
+    #[must_use]
     fn from(value: &str) -> Self {
         Self::String(String::from(value))
     }
 }
 
 impl From<String> for RustType {
+    #[must_use]
     fn from(value: String) -> Self {
         Self::String(value)
     }
 }
 
 impl From<i32> for RustType {
+    #[must_use]
     fn from(value: i32) -> Self {
         Self::Integer(value)
     }
 }
 
 impl From<HashMap<String, RustType>> for RustType {
+    #[must_use]
     fn from(value: HashMap<String, Self>) -> Self {
         Self::Object(value)
     }
 }
 
 impl From<Vec<RustType>> for RustType {
+    #[must_use]
     fn from(value: Vec<Self>) -> Self {
         Self::List(value)
     }
 }
 
 impl JsonType<RustType> for RustType {
+    #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
         if let Self::List(v) = self {
             Some(Box::new(v.iter()))
@@ -69,6 +78,7 @@ impl JsonType<RustType> for RustType {
         }
     }
 
+    #[must_use]
     fn as_boolean(&self) -> Option<bool> {
         if let Self::Boolean(v) = self {
             Some(*v)
@@ -77,6 +87,7 @@ impl JsonType<RustType> for RustType {
         }
     }
 
+    #[must_use]
     fn as_integer(&self) -> Option<i128> {
         if let Self::Integer(v) = self {
             Some(i128::from(*v))
@@ -85,6 +96,7 @@ impl JsonType<RustType> for RustType {
         }
     }
 
+    #[must_use]
     fn as_null(&self) -> Option<()> {
         if let Self::Null = self {
             Some(())
@@ -93,6 +105,7 @@ impl JsonType<RustType> for RustType {
         }
     }
 
+    #[must_use]
     fn as_number(&self) -> Option<f64> {
         if let Self::Integer(v) = self {
             Some(f64::from(*v))
@@ -101,6 +114,7 @@ impl JsonType<RustType> for RustType {
         }
     }
 
+    #[must_use]
     fn as_object(&self) -> Option<JsonMap<Self>>
     where
         for<'json> JsonMap<'json, Self>: JsonMapTrait<'json, Self>,
@@ -112,6 +126,7 @@ impl JsonType<RustType> for RustType {
         }
     }
 
+    #[must_use]
     fn as_string(&self) -> Option<&str> {
         if let Self::String(s) = self {
             Some(s)
@@ -120,6 +135,7 @@ impl JsonType<RustType> for RustType {
         }
     }
 
+    #[must_use]
     fn get_attribute(&self, attribute_name: &str) -> Option<&Self> {
         if let Self::Object(object) = self {
             object.get(attribute_name)
@@ -128,6 +144,7 @@ impl JsonType<RustType> for RustType {
         }
     }
 
+    #[must_use]
     fn get_index(&self, index: usize) -> Option<&Self> {
         if let Self::List(array) = self {
             array.get(index)
@@ -139,6 +156,7 @@ impl JsonType<RustType> for RustType {
 
 impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
     #[inline]
+    #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &RustType)> + 'json> {
         if let RustType::Object(hash_map) = self.deref() {
             Box::new(hash_map.iter().map(|(k, v)| (k.as_str(), v)))

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -3,19 +3,16 @@ use json;
 use std::ops::Index;
 
 impl<'json> JsonMapTrait<'json, json::JsonValue> for JsonMap<'json, json::JsonValue> {
-    #[inline]
     #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         Box::new(self.entries().map(|(key, _)| key))
     }
 
-    #[inline]
     #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &json::JsonValue> + 'json> {
         Box::new(self.entries().map(|(_, value)| value))
     }
 
-    #[inline]
     #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &json::JsonValue)> + 'json> {
         Box::new(self.entries())

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -4,22 +4,26 @@ use std::ops::Index;
 
 impl<'json> JsonMapTrait<'json, json::JsonValue> for JsonMap<'json, json::JsonValue> {
     #[inline]
+    #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         Box::new(self.entries().map(|(key, _)| key))
     }
 
     #[inline]
+    #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &json::JsonValue> + 'json> {
         Box::new(self.entries().map(|(_, value)| value))
     }
 
     #[inline]
+    #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &json::JsonValue)> + 'json> {
         Box::new(self.entries())
     }
 }
 
 impl JsonType<json::JsonValue> for json::JsonValue {
+    #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
         if self.is_array() {
             Some(Box::new(self.members()))
@@ -28,10 +32,12 @@ impl JsonType<json::JsonValue> for json::JsonValue {
         }
     }
 
+    #[must_use]
     fn as_boolean(&self) -> Option<bool> {
         self.as_bool()
     }
 
+    #[must_use]
     fn as_integer(&self) -> Option<i128> {
         self.as_f64().and_then(
             // The ugly conversion here is needed because rust-json internally does not
@@ -47,6 +53,7 @@ impl JsonType<json::JsonValue> for json::JsonValue {
         )
     }
 
+    #[must_use]
     fn as_null(&self) -> Option<()> {
         if self.is_null() {
             Some(())
@@ -55,10 +62,12 @@ impl JsonType<json::JsonValue> for json::JsonValue {
         }
     }
 
+    #[must_use]
     fn as_number(&self) -> Option<f64> {
         self.as_f64()
     }
 
+    #[must_use]
     fn as_object(&self) -> Option<JsonMap<Self>>
     where
         for<'json> JsonMap<'json, Self>: JsonMapTrait<'json, Self>,
@@ -70,10 +79,12 @@ impl JsonType<json::JsonValue> for json::JsonValue {
         }
     }
 
+    #[must_use]
     fn as_string(&self) -> Option<&str> {
         self.as_str()
     }
 
+    #[must_use]
     fn get_attribute(&self, attribute_name: &str) -> Option<&Self> {
         let extracted_value = self.index(attribute_name);
         if let Self::Null = extracted_value {
@@ -83,6 +94,7 @@ impl JsonType<json::JsonValue> for json::JsonValue {
         }
     }
 
+    #[must_use]
     fn get_index(&self, index: usize) -> Option<&Self> {
         let extracted_value = self.index(index);
         if let Self::Null = extracted_value {

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -8,7 +8,6 @@ use pyo3::{
 use std::{convert::TryInto, ops::Deref};
 
 impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
-    #[inline]
     #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         match PyTryInto::<PyDict>::try_into(self.deref()) {
@@ -17,7 +16,6 @@ impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
         }
     }
 
-    #[inline]
     #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &PyAny> + 'json> {
         match PyTryInto::<PyDict>::try_into(self.deref()) {
@@ -26,7 +24,6 @@ impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
         }
     }
 
-    #[inline]
     #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &PyAny)> + 'json> {
         match PyTryInto::<PyDict>::try_into(self.deref()) {

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -8,6 +8,8 @@ use pyo3::{
 use std::{convert::TryInto, ops::Deref};
 
 impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
+    #[inline]
+    #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         match PyTryInto::<PyDict>::try_into(self.deref()) {
             Ok(python_dict) => Box::new(python_dict.iter().filter_map(|(k, _)| k.as_string())),
@@ -15,6 +17,8 @@ impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
         }
     }
 
+    #[inline]
+    #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &PyAny> + 'json> {
         match PyTryInto::<PyDict>::try_into(self.deref()) {
             Ok(python_dict) => Box::new(python_dict.iter().map(|(_, v)| v)),
@@ -22,6 +26,8 @@ impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
         }
     }
 
+    #[inline]
+    #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &PyAny)> + 'json> {
         match PyTryInto::<PyDict>::try_into(self.deref()) {
             Ok(python_dict) => Box::new(python_dict.iter().filter_map(|(k, v)| k.as_string().map(|k_string| (k_string, v)).or(None))),
@@ -31,6 +37,7 @@ impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
 }
 
 impl JsonType<PyAny> for PyAny {
+    #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
         match PyTryInto::<PySequence>::try_into(self) {
             Err(_) => None,
@@ -47,10 +54,12 @@ impl JsonType<PyAny> for PyAny {
         }
     }
 
+    #[must_use]
     fn as_boolean(&self) -> Option<bool> {
         self.extract().ok()
     }
 
+    #[must_use]
     fn as_integer(&self) -> Option<i128> {
         self.extract().ok().and_then(|value| {
             // In python `assert isinstance(True, int) is True` is correct
@@ -64,6 +73,7 @@ impl JsonType<PyAny> for PyAny {
         })
     }
 
+    #[must_use]
     fn as_null(&self) -> Option<()> {
         if self.is_none() {
             Some(())
@@ -72,6 +82,7 @@ impl JsonType<PyAny> for PyAny {
         }
     }
 
+    #[must_use]
     fn as_number(&self) -> Option<f64> {
         self.extract().ok().and_then(|value| {
             // pyo3 is able to convert a boolean value into a f64 instance
@@ -85,6 +96,7 @@ impl JsonType<PyAny> for PyAny {
         })
     }
 
+    #[must_use]
     fn as_object(&self) -> Option<JsonMap<Self>>
     where
         for<'json> JsonMap<'json, Self>: JsonMapTrait<'json, Self>,
@@ -92,10 +104,12 @@ impl JsonType<PyAny> for PyAny {
         PyTryInto::<PyDict>::try_into(self).ok().map(|_| JsonMap::new(self))
     }
 
+    #[must_use]
     fn as_string(&self) -> Option<&str> {
         self.extract().ok()
     }
 
+    #[must_use]
     fn get_attribute(&self, attribute_name: &str) -> Option<&Self> {
         if let Ok(python_dict) = PyTryInto::<PyDict>::try_into(self) {
             return (python_dict as &PyDict).get_item(attribute_name);
@@ -103,6 +117,7 @@ impl JsonType<PyAny> for PyAny {
         None
     }
 
+    #[must_use]
     fn get_index(&self, index: usize) -> Option<&Self> {
         if let Ok(idx) = TryInto::<isize>::try_into(index) {
             if let Ok(python_sequence) = PyTryInto::<PySequence>::try_into(self) {

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -2,7 +2,6 @@ use crate::json_type::{JsonMap, JsonMapTrait, JsonType};
 use serde_json;
 
 impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json::Value> {
-    #[inline]
     #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_object() {
@@ -15,7 +14,6 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
         }
     }
 
-    #[inline]
     #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &serde_json::Value> + 'json> {
         if let Some(obj) = self.as_object() {
@@ -28,7 +26,6 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
         }
     }
 
-    #[inline]
     #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &serde_json::Value)> + 'json> {
         if let Some(obj) = self.as_object() {

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -3,6 +3,7 @@ use serde_json;
 
 impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json::Value> {
     #[inline]
+    #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.keys().map(AsRef::as_ref))
@@ -15,6 +16,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 
     #[inline]
+    #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &serde_json::Value> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.values())
@@ -27,6 +29,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 
     #[inline]
+    #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &serde_json::Value)> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.iter().map(|(k, v)| (k.as_ref(), v)))
@@ -40,6 +43,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
 }
 
 impl JsonType<serde_json::Value> for serde_json::Value {
+    #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_array() {
             Some(Box::new(vec.iter()))
@@ -48,10 +52,12 @@ impl JsonType<serde_json::Value> for serde_json::Value {
         }
     }
 
+    #[must_use]
     fn as_boolean(&self) -> Option<bool> {
         self.as_bool()
     }
 
+    #[must_use]
     fn as_integer(&self) -> Option<i128> {
         if let Some(value) = self.as_i64() {
             Some(i128::from(value))
@@ -60,14 +66,17 @@ impl JsonType<serde_json::Value> for serde_json::Value {
         }
     }
 
+    #[must_use]
     fn as_null(&self) -> Option<()> {
         self.as_null()
     }
 
+    #[must_use]
     fn as_number(&self) -> Option<f64> {
         self.as_f64()
     }
 
+    #[must_use]
     fn as_object(&self) -> Option<JsonMap<Self>>
     where
         for<'json> JsonMap<'json, Self>: JsonMapTrait<'json, Self>,
@@ -79,18 +88,22 @@ impl JsonType<serde_json::Value> for serde_json::Value {
         }
     }
 
+    #[must_use]
     fn as_string(&self) -> Option<&str> {
         self.as_str()
     }
 
+    #[must_use]
     fn get_attribute(&self, attribute_name: &str) -> Option<&Self> {
         self.get(attribute_name)
     }
 
+    #[must_use]
     fn get_index(&self, index: usize) -> Option<&Self> {
         self.get(index)
     }
 
+    #[must_use]
     fn has_attribute(&self, attribute_name: &str) -> bool {
         self.get(attribute_name).is_some()
     }

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -2,7 +2,6 @@ use crate::json_type::{JsonMap, JsonMapTrait, JsonType};
 use serde_yaml;
 
 impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml::Value> {
-    #[inline]
     #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_mapping() {
@@ -15,7 +14,6 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
         }
     }
 
-    #[inline]
     #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &serde_yaml::Value> + 'json> {
         if let Some(obj) = self.as_mapping() {
@@ -28,7 +26,6 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
         }
     }
 
-    #[inline]
     #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &serde_yaml::Value)> + 'json> {
         if let Some(obj) = self.as_mapping() {

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -3,6 +3,7 @@ use serde_yaml;
 
 impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml::Value> {
     #[inline]
+    #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(key, _)| (key.as_str().unwrap())))
@@ -15,6 +16,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 
     #[inline]
+    #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &serde_yaml::Value> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(_, value)| value))
@@ -27,6 +29,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 
     #[inline]
+    #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &serde_yaml::Value)> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(key, value)| (key.as_str().unwrap(), value)))
@@ -40,6 +43,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
 }
 
 impl JsonType<serde_yaml::Value> for serde_yaml::Value {
+    #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn Iterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_sequence() {
             Some(Box::new(vec.iter()))
@@ -48,10 +52,12 @@ impl JsonType<serde_yaml::Value> for serde_yaml::Value {
         }
     }
 
+    #[must_use]
     fn as_boolean(&self) -> Option<bool> {
         self.as_bool()
     }
 
+    #[must_use]
     fn as_integer(&self) -> Option<i128> {
         if let Some(value) = self.as_i64() {
             Some(i128::from(value))
@@ -60,14 +66,17 @@ impl JsonType<serde_yaml::Value> for serde_yaml::Value {
         }
     }
 
+    #[must_use]
     fn as_null(&self) -> Option<()> {
         self.as_null()
     }
 
+    #[must_use]
     fn as_number(&self) -> Option<f64> {
         self.as_f64()
     }
 
+    #[must_use]
     fn as_object(&self) -> Option<JsonMap<Self>>
     where
         for<'json> JsonMap<'json, Self>: JsonMapTrait<'json, Self>,
@@ -79,18 +88,22 @@ impl JsonType<serde_yaml::Value> for serde_yaml::Value {
         }
     }
 
+    #[must_use]
     fn as_string(&self) -> Option<&str> {
         self.as_str()
     }
 
+    #[must_use]
     fn get_attribute(&self, attribute_name: &str) -> Option<&Self> {
         self.get(attribute_name)
     }
 
+    #[must_use]
     fn get_index(&self, index: usize) -> Option<&Self> {
         self.get(index)
     }
 
+    #[must_use]
     fn has_attribute(&self, attribute_name: &str) -> bool {
         self.get(attribute_name).is_some()
     }


### PR DESCRIPTION
In PR #16 clippy has started complaining about [``must_use_candidate``](https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate) lint.

As it ensures at compilation time that the return value of functions is used, I think that it is a great feature to ensure that no needless calls are sent if the result is not used.

Something else that I'm fixing on this PR is related to the presence of `#[inline]`.
Inlining functions increases compilation time and binary size but at the same time there is the potential to remove some function calls, hence improving performances.
As we have no real-metrics proving improvements related to usage of `#[inline]`, I'm opting to remove it and to use the compiler intelligence for inlining (we might still re-add it if we have data).
