### PR TITLE
Deactivate cache on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,14 +55,14 @@ before_script:
 script:
 - make "${MAKE_TARGET}"
 
-cache:
-  timeout: 3600
-  directories:
-  - ${HOME}/.cache/pre-commit
-  - ${CODECOV_DIR}
-  - ${HOME}/.cargo/
-  - ${TRAVIS_BUILD_DIR}/target
-  - /C/ProgramData/chocolatey
+# cache:
+#   timeout: 3600
+#   directories:
+#   - ${HOME}/.cache/pre-commit
+#   - ${CODECOV_DIR}
+#   - ${HOME}/.cargo/
+#   - ${TRAVIS_BUILD_DIR}/target
+#   - /C/ProgramData/chocolatey
 
 # notifications:
 #   email: false

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -40,8 +40,6 @@ install_lint_tools() {
       # Workaround in case clippy is not available in the current nightly release (https://github.com/rust-lang/rust-clippy#travis-ci)
       rustup component add clippy --toolchain="${TRAVIS_RUST_VERSION}" || cargo +"${TRAVIS_RUST_VERSION}" install --git https://github.com/rust-lang/rust-clippy/ --force clippy
     fi
-  else
-    echo "# Skipping lint-tools install as target is not coverage" > /dev/stderr
   fi
 }
 


### PR DESCRIPTION
The reason for this change is simple: caching is great, but if not properly managed the cache directory size grows and with it it increases the time of fetching the cache before the build and as changes might be present (due to lack of cache optimisation on the repository) it increases the time spent to upload back the caches.

So considering this I'm de-activating travis cache for now.
