### PR TITLE
Relax JsonType to not be thread safe and define ThreadSafeJsonType to provide the thread safe version

### DIFF
--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -67,7 +67,7 @@ where
 // This trait allows us to have a 1:1 mapping with serde_json, generally used by rust libraries
 // but gives us the power to use different objects from serde_json. This gives us the ability
 // to support usage of different data-types like PyObject from pyo3 in case of python bindings
-pub trait JsonType<T>: Debug + Sync + Send
+pub trait JsonType<T>: Debug
 where
     T: JsonType<T>,
 {
@@ -145,6 +145,12 @@ where
             }
         }
     }
+}
+
+pub trait ThreadSafeJsonType<T>: JsonType<T> + Sync + Send
+where
+    T: JsonType<T>,
+{
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,5 +58,5 @@ mod json_type;
 mod rust_type;
 pub mod traits;
 
-pub use json_type::{get_fragment, EnumJsonType, JsonMap, JsonMapTrait, JsonType};
+pub use json_type::{get_fragment, EnumJsonType, JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType};
 pub use rust_type::RustType;

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -1,4 +1,7 @@
-use crate::json_type::{JsonMap, JsonMapTrait, JsonType};
+use crate::{
+    json_type::{JsonMap, JsonMapTrait, JsonType},
+    ThreadSafeJsonType,
+};
 use json;
 use std::ops::Index;
 
@@ -101,6 +104,8 @@ impl JsonType<json::JsonValue> for json::JsonValue {
         }
     }
 }
+
+impl dyn ThreadSafeJsonType<json::JsonValue> {}
 
 #[cfg(test)]
 mod tests_json_map_trait {

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -1,4 +1,7 @@
-use crate::json_type::{JsonMap, JsonMapTrait, JsonType};
+use crate::{
+    json_type::{JsonMap, JsonMapTrait, JsonType},
+    ThreadSafeJsonType,
+};
 use serde_json;
 
 impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json::Value> {
@@ -105,6 +108,8 @@ impl JsonType<serde_json::Value> for serde_json::Value {
         self.get(attribute_name).is_some()
     }
 }
+
+impl dyn ThreadSafeJsonType<serde_json::Value> {}
 
 #[cfg(test)]
 mod tests_json_map_trait {

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -1,4 +1,7 @@
-use crate::json_type::{JsonMap, JsonMapTrait, JsonType};
+use crate::{
+    json_type::{JsonMap, JsonMapTrait, JsonType},
+    ThreadSafeJsonType,
+};
 use serde_yaml;
 
 impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml::Value> {
@@ -105,6 +108,8 @@ impl JsonType<serde_yaml::Value> for serde_yaml::Value {
         self.get(attribute_name).is_some()
     }
 }
+
+impl dyn ThreadSafeJsonType<serde_yaml::Value> {}
 
 #[cfg(test)]
 mod tests_yaml_map_trait {


### PR DESCRIPTION
This PR is needed in order to allow PyO3 support (which made Py* Objects not thread safe).

The JsonType object might eventually be made stricter again, but in the mean time `ThreadSafeJsonType` has been defined in order to have a stricter thread safe JsonType version for the inner types that supports it