### PR TITLE
Release v0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,12 @@ matrix:
     rust: stable
   - os: linux
     dist: xenial
-    rust: nightly-2019-10-19  # Running on nighly to ensure that all the codebase are checked by the linters)
-                              # Using an "older" nightly version due to difficulties into building rustfmt on latest nighyly
+    # Before updating this make sure that nighly-YYYY-MM-DD contains either rustfmt and clippy
+    # Use
+    #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy`
+    #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustfmt`
+    # to validate that both tools are available
+    rust: nightly-2019-12-19
     env: MAKE_TARGET=lint
   allow_failures:
   - env: MAKE_TARGET=lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.6.0 (2019-12-19)
+------------------
+- Relax ``JsonType`` to not be thread safe and define ``ThreadSafeJsonType`` to provide the thread safe version - [PR #22](https://github.com/macisamuele/json-trait-rs/pull/22)
+
 0.5.1 (2019-10-19)
 ------------------
 - Reduce usage of ``#[inline]`` and ensure that method results are used via ``#[must_use]`` - [PR #17](https://github.com/macisamuele/json-trait-rs/pull/17)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "json-trait-rs"
 readme = "README.md"
 publish = true
-version = "0.5.1"
+version = "0.6.0"
 
 [badges]
 codecov = { repository = "macisamuele/json-trait-rs", branch = "master", service = "github" }

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -147,6 +147,7 @@ where
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
 pub trait ThreadSafeJsonType<T>: JsonType<T> + Sync + Send
 where
     T: JsonType<T>,

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -1,4 +1,7 @@
-use crate::json_type::{JsonMap, JsonMapTrait, JsonType};
+use crate::{
+    json_type::{JsonMap, JsonMapTrait, JsonType},
+    ThreadSafeJsonType,
+};
 use std::{collections::hash_map::HashMap, ops::Deref};
 
 #[allow(clippy::module_name_repetitions)]
@@ -153,6 +156,8 @@ impl JsonType<RustType> for RustType {
         }
     }
 }
+
+impl ThreadSafeJsonType<RustType> for RustType {}
 
 impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
     #[must_use]


### PR DESCRIPTION
This PR releases the new version of json-trait-rs

As bonus points it bumps the rust nightly version used to run ints and makes sure that `RustType` is a ThreadSafeJsonType  