### PR TITLE
Run dependency audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
     #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy`
     #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustfmt`
     # to validate that both tools are available
-    rust: nightly-2019-12-19
+    rust: nightly-2020-02-01
     env: MAKE_TARGET=lint
   allow_failures:
   - env: MAKE_TARGET=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,10 @@ matrix:
     rust: stable
   - os: linux
     dist: xenial
+    env: MAKE_TARGET=audit
+    rust: nightly
+  - os: linux
+    dist: xenial
     # Before updating this make sure that nighly-YYYY-MM-DD contains either rustfmt and clippy
     # Use
     #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy`

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,7 @@ matrix:
     rust: nightly
     env: MAKE_TARGET=test-all-flavours
   - os: osx
-    rust: stable
-    env: MAKE_TARGET=test-all-flavours
-  - os: osx
     rust: nightly
-    env: MAKE_TARGET=test-all-flavours
-  - os: windows
-    rust: stable
     env: MAKE_TARGET=test-all-flavours
   - os: windows
     rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ env:
 matrix:
   include:
   - os: linux
-    dist: xenial
+    dist: bionic
     env: MAKE_TARGET=coverage
     rust: nightly  # Running on nightly to ensure that all the traits are actually tested
   - os: linux
-    dist: xenial
+    dist: bionic
     rust: stable
     env: MAKE_TARGET=test-all-flavours
   - os: linux
-    dist: xenial
+    dist: bionic
     rust: nightly
     env: MAKE_TARGET=test-all-flavours
   - os: osx
@@ -27,15 +27,15 @@ matrix:
     rust: nightly
     env: MAKE_TARGET=test-all-flavours PYTHON_SYS_EXECUTABLE=/C/Python37/python.exe PATH=${PATH}:/C/Python37/:/C/Python37/Scripts
   - os: linux
-    dist: xenial
+    dist: bionic
     env: MAKE_TARGET=doc
     rust: stable
   - os: linux
-    dist: xenial
+    dist: bionic
     env: MAKE_TARGET=audit
     rust: nightly
   - os: linux
-    dist: xenial
+    dist: bionic
     # Before updating this make sure that nighly-YYYY-MM-DD contains either rustfmt and clippy
     # Use
     #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy`

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ test:
 test-all-flavours:
 	$(call call_all_features,test)
 
+.PHONY: audit
+audit:
+	cargo +${RUST_TOOLCHAIN} audit
+
 .PHONY: doc
 doc:
 	cargo +${RUST_TOOLCHAIN} doc --no-deps ${CARGO_ARGS}

--- a/scripts/travis/before_script.sh
+++ b/scripts/travis/before_script.sh
@@ -9,3 +9,4 @@ rustup show
 rustc --version --verbose
 cargo --version --verbose
 if [[ ${MAKE_TARGET} == "coverage" ]]; then grcov --version; fi
+if [[ ${MAKE_TARGET} == "audit" ]]; then cargo audit --version; fi

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -17,6 +17,12 @@ install_python() {
   fi
 }
 
+install_audit() {
+  if [[ ${MAKE_TARGET} == "audit" ]]; then
+    cargo install cargo-audit
+  fi
+}
+
 install_grcov() {
   if [[ ${MAKE_TARGET} == "coverage" ]]; then
     if ! command -v grcov @> /dev/null; then
@@ -68,3 +74,4 @@ install_python
 install_grcov
 download_codecov_bash_script
 install_lint_tools
+install_audit


### PR DESCRIPTION
The main goal of this PR is to introduce [`cargo audit`](https://github.com/RustSec/cargo-audit) into `json-trait-rs`.

There are few additional "bonus" updates on this PR, mostly related to travis updates ;)