### PR TITLE
Update interfaces to be more rust like

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1"
 test-case = "0"
 
 [dependencies]
+failure = "0"
 json = { version = "0", optional = true }
 pyo3 = { version = "0", optional = true }
 serde_json = { version = "1", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,6 @@
+use failure::Fail;
+#[derive(Debug, Fail, PartialEq)]
+pub enum Error {
+    #[fail(display = "Unsupported primitive type `{}`. Available types are defined by `json_trait_rs::PrimitiveType::VARIANTS`", type_str)]
+    UnsupportedPrimitiveType { type_str: String },
+}

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -2,7 +2,7 @@ use crate::{fragment::fragment_components_from_fragment, RustType};
 use std::{fmt::Debug, ops::Deref};
 
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Copy, EnumIter, Eq, Debug, Display, PartialEq)]
+#[derive(Clone, Copy, EnumIter, EnumVariantNames, Eq, Debug, Display, PartialEq)]
 pub enum PrimitiveType {
     // We assume that all the drafts will have the same primitive types
     Array,

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -96,7 +96,7 @@ where
 // This trait allows us to have a 1:1 mapping with serde_json, generally used by rust libraries
 // but gives us the power to use different objects from serde_json. This gives us the ability
 // to support usage of different data-types like PyObject from pyo3 in case of python bindings
-pub trait JsonType<T>
+pub trait JsonType<T>: Debug
 where
     T: JsonType<T> + Into<RustType>,
 {

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, ops::Deref};
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Clone, Copy, EnumIter, Eq, Debug, Display, PartialEq)]
-pub enum EnumJsonType {
+pub enum PrimitiveType {
     // We assume that all the drafts will have the same primitive types
     Array,
     Boolean,
@@ -14,7 +14,7 @@ pub enum EnumJsonType {
     String,
 }
 
-impl EnumJsonType {
+impl PrimitiveType {
     #[must_use]
     pub fn from_type(type_string: &str) -> Option<Self>
     where
@@ -149,25 +149,25 @@ where
         self.get_attribute(attribute_name).is_some()
     }
 
-    fn primitive_type(&self) -> EnumJsonType
+    fn primitive_type(&self) -> PrimitiveType
     where
         for<'json> JsonMap<'json, T>: JsonMapTrait<'json, T>,
     {
         // This might not be efficient, but it could be comfortable to quickly extract the type especially while debugging
         if self.is_array() {
-            EnumJsonType::Array
+            PrimitiveType::Array
         } else if self.is_boolean() {
-            EnumJsonType::Boolean
+            PrimitiveType::Boolean
         } else if self.is_integer() {
-            EnumJsonType::Integer
+            PrimitiveType::Integer
         } else if self.is_null() {
-            EnumJsonType::Null
+            PrimitiveType::Null
         } else if self.is_number() {
-            EnumJsonType::Number
+            PrimitiveType::Number
         } else if self.is_object() {
-            EnumJsonType::Object
+            PrimitiveType::Object
         } else if self.is_string() {
-            EnumJsonType::String
+            PrimitiveType::String
         } else {
             #[allow(unsafe_code)]
             unsafe {
@@ -220,8 +220,8 @@ where
     for fragment_part in fragment_components_from_fragment(fragment) {
         if let Some(value) = result {
             result = match value.primitive_type() {
-                EnumJsonType::Object => value.get_attribute(fragment_part.as_str()),
-                EnumJsonType::Array => fragment_part.parse::<usize>().map(|index| value.get_index(index)).ok().unwrap_or(None),
+                PrimitiveType::Object => value.get_attribute(fragment_part.as_str()),
+                PrimitiveType::Array => fragment_part.parse::<usize>().map(|index| value.get_index(index)).ok().unwrap_or(None),
                 _ => None,
             };
         }
@@ -231,7 +231,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{get_fragment, EnumJsonType, JsonType};
+    use super::{get_fragment, JsonType, PrimitiveType};
     use crate::rust_type::RustType;
     use test_case::test_case;
 
@@ -245,25 +245,25 @@ mod tests {
         check(&RustType::default())
     }
 
-    #[test_case("array", Some(EnumJsonType::Array))]
-    #[test_case("integer", Some(EnumJsonType::Integer))]
-    #[test_case("number", Some(EnumJsonType::Number))]
-    #[test_case("null", Some(EnumJsonType::Null))]
-    #[test_case("object", Some(EnumJsonType::Object))]
-    #[test_case("string", Some(EnumJsonType::String))]
+    #[test_case("array", Some(PrimitiveType::Array))]
+    #[test_case("integer", Some(PrimitiveType::Integer))]
+    #[test_case("number", Some(PrimitiveType::Number))]
+    #[test_case("null", Some(PrimitiveType::Null))]
+    #[test_case("object", Some(PrimitiveType::Object))]
+    #[test_case("string", Some(PrimitiveType::String))]
     #[test_case("an invalid type", None)]
-    fn test_enum_primitive_type_from_type(type_str: &str, expected_option_enum_primitive_type: Option<EnumJsonType>) {
-        assert_eq!(EnumJsonType::from_type(type_str), expected_option_enum_primitive_type);
+    fn test_primitive_type_from_type(type_str: &str, expected_option_primitive_type: Option<PrimitiveType>) {
+        assert_eq!(PrimitiveType::from_type(type_str), expected_option_primitive_type);
     }
 
-    #[test_case(EnumJsonType::Array, "array")]
-    #[test_case(EnumJsonType::Integer, "integer")]
-    #[test_case(EnumJsonType::Number, "number")]
-    #[test_case(EnumJsonType::Null, "null")]
-    #[test_case(EnumJsonType::Object, "object")]
-    #[test_case(EnumJsonType::String, "string")]
-    fn test_enum_primitive_type_to_type(enum_primitive_type: EnumJsonType, expected_type_str: &str) {
-        assert_eq!(enum_primitive_type.to_type(), expected_type_str);
+    #[test_case(PrimitiveType::Array, "array")]
+    #[test_case(PrimitiveType::Integer, "integer")]
+    #[test_case(PrimitiveType::Number, "number")]
+    #[test_case(PrimitiveType::Null, "null")]
+    #[test_case(PrimitiveType::Object, "object")]
+    #[test_case(PrimitiveType::String, "string")]
+    fn test_primitive_type_to_type(primitive_type: PrimitiveType, expected_type_str: &str) {
+        assert_eq!(primitive_type.to_type(), expected_type_str);
     }
 
     #[test]

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -2,7 +2,7 @@ use crate::{fragment::fragment_components_from_fragment, Error, RustType};
 use std::{convert::TryFrom, fmt::Debug, ops::Deref};
 
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Copy, EnumIter, EnumVariantNames, Eq, Debug, Display, PartialEq)]
+#[derive(Clone, Copy, EnumIter, EnumVariantNames, Eq, Hash, Debug, Display, PartialEq)]
 pub enum PrimitiveType {
     // We assume that all the drafts will have the same primitive types
     Array,

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -235,6 +235,16 @@ mod tests {
     use crate::rust_type::RustType;
     use test_case::test_case;
 
+    #[test]
+    fn test_ensure_that_jsontype_can_be_made_into_an_object() {
+        // The code will fail to compile if JsonType cannot be made into an object
+        // Adding `fn foo() {}` into the trait will result into
+        // error[E0038]: the trait `json_type::JsonType` cannot be made into an object
+        //     associated function `foo` has no `self` parameter
+        fn check<T>(_v: &dyn JsonType<T>) {}
+        check(&RustType::default())
+    }
+
     #[test_case("array", Some(EnumJsonType::Array))]
     #[test_case("integer", Some(EnumJsonType::Integer))]
     #[test_case("number", Some(EnumJsonType::Number))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,14 @@ extern crate serde_json;
 #[macro_use]
 pub mod macros;
 
+mod error;
 mod fragment;
 mod json_type;
 mod rust_type;
 pub mod traits;
 
-pub use json_type::{get_fragment, JsonMap, JsonMapTrait, JsonType, PrimitiveType, ThreadSafeJsonType};
-pub use rust_type::RustType;
+pub use crate::{
+    error::Error,
+    json_type::{get_fragment, JsonMap, JsonMapTrait, JsonType, PrimitiveType, ThreadSafeJsonType},
+    rust_type::RustType,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@ extern crate strum_macros;
 #[macro_use]
 extern crate lazy_static;
 #[cfg(all(test, any(feature = "trait_serde_json", feature = "trait_serde_yaml", feature = "trait_json")))]
-#[cfg(test)]
 #[macro_use]
 extern crate serde_json;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,5 +57,5 @@ mod json_type;
 mod rust_type;
 pub mod traits;
 
-pub use json_type::{get_fragment, EnumJsonType, JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType};
+pub use json_type::{get_fragment, JsonMap, JsonMapTrait, JsonType, PrimitiveType, ThreadSafeJsonType};
 pub use rust_type::RustType;

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -5,12 +5,13 @@ use crate::{
 use std::{collections::hash_map::HashMap, ops::Deref};
 
 #[allow(clippy::module_name_repetitions)]
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum RustType {
     Null,
     Boolean(bool),
     String(String),
-    Integer(i32),
+    Integer(i128),
+    Number(f64),
     List(Vec<RustType>),
     Object(HashMap<String, RustType>),
 }
@@ -53,7 +54,35 @@ impl From<String> for RustType {
 impl From<i32> for RustType {
     #[must_use]
     fn from(value: i32) -> Self {
+        Self::Integer(value.into())
+    }
+}
+
+impl From<i64> for RustType {
+    #[must_use]
+    fn from(value: i64) -> Self {
+        Self::Integer(value.into())
+    }
+}
+
+impl From<i128> for RustType {
+    #[must_use]
+    fn from(value: i128) -> Self {
         Self::Integer(value)
+    }
+}
+
+impl From<f32> for RustType {
+    #[must_use]
+    fn from(value: f32) -> Self {
+        Self::Number(value.into())
+    }
+}
+
+impl From<f64> for RustType {
+    #[must_use]
+    fn from(value: f64) -> Self {
+        Self::Number(value)
     }
 }
 
@@ -93,7 +122,7 @@ impl JsonType<RustType> for RustType {
     #[must_use]
     fn as_integer(&self) -> Option<i128> {
         if let Self::Integer(v) = self {
-            Some(i128::from(*v))
+            Some(*v)
         } else {
             None
         }
@@ -110,8 +139,8 @@ impl JsonType<RustType> for RustType {
 
     #[must_use]
     fn as_number(&self) -> Option<f64> {
-        if let Self::Integer(v) = self {
-            Some(f64::from(*v))
+        if let Self::Number(v) = self {
+            Some(*v)
         } else {
             None
         }
@@ -206,7 +235,7 @@ mod smoke_test {
         assert_eq!(testing_type_instance.is_boolean(), false);
         assert_eq!(testing_type_instance.is_integer(), true);
         assert_eq!(testing_type_instance.is_null(), false);
-        assert_eq!(testing_type_instance.is_number(), true);
+        assert_eq!(testing_type_instance.is_number(), false);
         assert_eq!(testing_type_instance.is_object(), false);
         assert_eq!(testing_type_instance.is_string(), false);
     }

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -1,9 +1,15 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType},
-    ThreadSafeJsonType,
+    json_type::{to_rust_type, JsonMap, JsonMapTrait, JsonType},
+    RustType, ThreadSafeJsonType,
 };
 use json;
 use std::ops::Index;
+
+impl Into<RustType> for json::JsonValue {
+    fn into(self) -> RustType {
+        to_rust_type(&self)
+    }
+}
 
 impl<'json> JsonMapTrait<'json, json::JsonValue> for JsonMap<'json, json::JsonValue> {
     #[must_use]

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -148,17 +148,17 @@ mod tests_json_map_trait {
 
 #[cfg(test)]
 mod tests_primitive_type_trait {
-    use crate::json_type::{EnumJsonType, JsonType};
+    use crate::json_type::{JsonType, PrimitiveType};
     use test_case::test_case;
 
-    #[test_case(&rust_json![[]], EnumJsonType::Array)]
-    #[test_case(&rust_json![true], EnumJsonType::Boolean)]
-    #[test_case(&rust_json![1], EnumJsonType::Integer)]
-    #[test_case(&rust_json![null], EnumJsonType::Null)]
-    #[test_case(&rust_json![1.2], EnumJsonType::Number)]
-    #[test_case(&rust_json![{"prop": "value"}], EnumJsonType::Object)]
-    #[test_case(&rust_json!["string"], EnumJsonType::String)]
-    fn test_primitive_type(value: &json::JsonValue, expected_value: EnumJsonType) {
+    #[test_case(&rust_json![[]], PrimitiveType::Array)]
+    #[test_case(&rust_json![true], PrimitiveType::Boolean)]
+    #[test_case(&rust_json![1], PrimitiveType::Integer)]
+    #[test_case(&rust_json![null], PrimitiveType::Null)]
+    #[test_case(&rust_json![1.2], PrimitiveType::Number)]
+    #[test_case(&rust_json![{"prop": "value"}], PrimitiveType::Object)]
+    #[test_case(&rust_json!["string"], PrimitiveType::String)]
+    fn test_primitive_type(value: &json::JsonValue, expected_value: PrimitiveType) {
         assert_eq!(JsonType::primitive_type(value), expected_value);
     }
 

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -1,4 +1,4 @@
-use crate::{JsonMap, JsonMapTrait, JsonType};
+use crate::{json_type::to_rust_type, JsonMap, JsonMapTrait, JsonType, RustType};
 #[cfg(test)]
 use pyo3::Python;
 use pyo3::{
@@ -6,6 +6,12 @@ use pyo3::{
     ObjectProtocol, PyTryInto,
 };
 use std::{convert::TryInto, ops::Deref};
+
+impl Into<RustType> for PyAny {
+    fn into(self) -> RustType {
+        to_rust_type(&self)
+    }
+}
 
 impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
     #[must_use]

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -187,19 +187,19 @@ mod tests_json_map_trait {
 #[cfg(test)]
 mod tests_primitive_type_trait {
     use crate::{
-        json_type::{EnumJsonType, JsonType},
+        json_type::{JsonType, PrimitiveType},
         traits::_pyo3::perform_python_check,
     };
     use test_case::test_case;
 
-    #[test_case("[]", EnumJsonType::Array)]
-    #[test_case("True", EnumJsonType::Boolean)]
-    #[test_case("1", EnumJsonType::Integer)]
-    #[test_case("None", EnumJsonType::Null)]
-    #[test_case("1.2", EnumJsonType::Number)]
-    #[test_case("{'prop': 'value'}", EnumJsonType::Object)]
-    #[test_case("'string'", EnumJsonType::String)]
-    fn test_primitive_type(python_code_string: &str, expected_value: EnumJsonType) {
+    #[test_case("[]", PrimitiveType::Array)]
+    #[test_case("True", PrimitiveType::Boolean)]
+    #[test_case("1", PrimitiveType::Integer)]
+    #[test_case("None", PrimitiveType::Null)]
+    #[test_case("1.2", PrimitiveType::Number)]
+    #[test_case("{'prop': 'value'}", PrimitiveType::Object)]
+    #[test_case("'string'", PrimitiveType::String)]
+    fn test_primitive_type(python_code_string: &str, expected_value: PrimitiveType) {
         perform_python_check(python_code_string, |python_object_ref| {
             assert_eq!(JsonType::primitive_type(python_object_ref), expected_value);
         })

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -147,17 +147,17 @@ mod tests_json_map_trait {
 
 #[cfg(test)]
 mod tests_primitive_type_trait {
-    use crate::json_type::{EnumJsonType, JsonType};
+    use crate::json_type::{JsonType, PrimitiveType};
     use test_case::test_case;
 
-    #[test_case(&json![[]], EnumJsonType::Array)]
-    #[test_case(&json![true], EnumJsonType::Boolean)]
-    #[test_case(&json![1], EnumJsonType::Integer)]
-    #[test_case(&json![null], EnumJsonType::Null)]
-    #[test_case(&json![1.2], EnumJsonType::Number)]
-    #[test_case(&json![{"prop": "value"}], EnumJsonType::Object)]
-    #[test_case(&json!["string"], EnumJsonType::String)]
-    fn test_primitive_type(value: &serde_json::Value, expected_value: EnumJsonType) {
+    #[test_case(&json![[]], PrimitiveType::Array)]
+    #[test_case(&json![true], PrimitiveType::Boolean)]
+    #[test_case(&json![1], PrimitiveType::Integer)]
+    #[test_case(&json![null], PrimitiveType::Null)]
+    #[test_case(&json![1.2], PrimitiveType::Number)]
+    #[test_case(&json![{"prop": "value"}], PrimitiveType::Object)]
+    #[test_case(&json!["string"], PrimitiveType::String)]
+    fn test_primitive_type(value: &serde_json::Value, expected_value: PrimitiveType) {
         assert_eq!(JsonType::primitive_type(value), expected_value);
     }
 

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -1,8 +1,14 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType},
-    ThreadSafeJsonType,
+    json_type::{to_rust_type, JsonMap, JsonMapTrait, JsonType},
+    RustType, ThreadSafeJsonType,
 };
 use serde_json;
+
+impl Into<RustType> for serde_json::Value {
+    fn into(self) -> RustType {
+        to_rust_type(&self)
+    }
+}
 
 impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json::Value> {
     #[must_use]

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -147,17 +147,17 @@ mod tests_yaml_map_trait {
 
 #[cfg(test)]
 mod tests_primitive_type_trait {
-    use crate::json_type::{EnumJsonType, JsonType};
+    use crate::json_type::{JsonType, PrimitiveType};
     use test_case::test_case;
 
-    #[test_case(&yaml![[]], EnumJsonType::Array)]
-    #[test_case(&yaml![true], EnumJsonType::Boolean)]
-    #[test_case(&yaml![1], EnumJsonType::Integer)]
-    #[test_case(&yaml![null], EnumJsonType::Null)]
-    #[test_case(&yaml![1.2], EnumJsonType::Number)]
-    #[test_case(&yaml![{"prop": "value"}], EnumJsonType::Object)]
-    #[test_case(&yaml!["string"], EnumJsonType::String)]
-    fn test_primitive_type(value: &serde_yaml::Value, expected_value: EnumJsonType) {
+    #[test_case(&yaml![[]], PrimitiveType::Array)]
+    #[test_case(&yaml![true], PrimitiveType::Boolean)]
+    #[test_case(&yaml![1], PrimitiveType::Integer)]
+    #[test_case(&yaml![null], PrimitiveType::Null)]
+    #[test_case(&yaml![1.2], PrimitiveType::Number)]
+    #[test_case(&yaml![{"prop": "value"}], PrimitiveType::Object)]
+    #[test_case(&yaml!["string"], PrimitiveType::String)]
+    fn test_primitive_type(value: &serde_yaml::Value, expected_value: PrimitiveType) {
         assert_eq!(JsonType::primitive_type(value), expected_value);
     }
 

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -1,8 +1,14 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType},
-    ThreadSafeJsonType,
+    json_type::{to_rust_type, JsonMap, JsonMapTrait, JsonType},
+    RustType, ThreadSafeJsonType,
 };
 use serde_yaml;
+
+impl Into<RustType> for serde_yaml::Value {
+    fn into(self) -> RustType {
+        to_rust_type(&self)
+    }
+}
 
 impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml::Value> {
     #[must_use]


### PR DESCRIPTION
The main goal of this PR is to make the repository be a bit more _rusty_.

`EnumJsonType` (not really a great name) got renamed into `PrimitiveType` and not exposes "standards" conversion traits instead of custom methods.

`JsonType` as well got updated and the trait now requires that all the concrete types implementing it have to implement `Into<RustType>` as well.

**NOTE**: In order to obtain `Into<RustType>` we needed to update `RustType` to be able to fully represent all the JSON objects, and so we needed to add support for `Number` case