### PR TITLE
Extract JsonType::to_rust_type into dedicated trait (ToRustType)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,3 @@ serde_json = { version = "1", optional = true }
 serde_yaml = { version = "0", optional = true }
 strum = "0"
 strum_macros = "0"
-unreachable = "1"

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -140,7 +140,7 @@ where
         } else {
             #[allow(unsafe_code)]
             unsafe {
-                unreachable::unreachable()
+                std::hint::unreachable_unchecked()
             }
         }
     }
@@ -166,7 +166,7 @@ where
         } else {
             #[allow(unsafe_code)]
             unsafe {
-                unreachable::unreachable()
+                std::hint::unreachable_unchecked()
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,6 @@ pub mod traits;
 
 pub use crate::{
     error::Error,
-    json_type::{get_fragment, JsonMap, JsonMapTrait, JsonType, PrimitiveType, ThreadSafeJsonType},
+    json_type::{get_fragment, JsonMap, JsonMapTrait, JsonType, PrimitiveType, ThreadSafeJsonType, ToRustType},
     rust_type::RustType,
 };

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -1,5 +1,5 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType},
+    json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
     ThreadSafeJsonType,
 };
 use std::{collections::hash_map::HashMap, ops::Deref};
@@ -100,6 +100,12 @@ impl From<Vec<RustType>> for RustType {
     }
 }
 
+impl ToRustType for RustType {
+    fn to_rust_type(&self) -> RustType {
+        self.clone()
+    }
+}
+
 impl JsonType<RustType> for RustType {
     #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
@@ -183,10 +189,6 @@ impl JsonType<RustType> for RustType {
         } else {
             None
         }
-    }
-
-    fn to_rust_type(&self) -> RustType {
-        self.clone()
     }
 }
 

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -200,7 +200,7 @@ impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
         } else {
             #[allow(unsafe_code)]
             unsafe {
-                unreachable::unreachable()
+                std::hint::unreachable_unchecked()
             }
         }
     }

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -1,5 +1,5 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType},
+    json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
     RustType, ThreadSafeJsonType,
 };
 use std::ops::Index;
@@ -9,6 +9,8 @@ impl Into<RustType> for json::JsonValue {
         self.to_rust_type()
     }
 }
+
+impl ToRustType for json::JsonValue {}
 
 impl<'json> JsonMapTrait<'json, json::JsonValue> for JsonMap<'json, json::JsonValue> {
     #[must_use]

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -1,6 +1,7 @@
-use crate::{json_type::JsonMap, JsonMapTrait, JsonType, RustType};
-#[cfg(test)]
-use pyo3::Python;
+use crate::{
+    json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
+    RustType,
+};
 use pyo3::{
     types::{PyAny, PyDict, PySequence},
     ObjectProtocol, PyTryInto,
@@ -12,6 +13,8 @@ impl Into<RustType> for PyAny {
         self.to_rust_type()
     }
 }
+
+impl ToRustType for PyAny {}
 
 impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
     #[must_use]
@@ -133,6 +136,7 @@ impl JsonType<PyAny> for PyAny {
 
 #[cfg(test)]
 fn perform_python_check(python_code_string: &str, check: impl Fn(&PyAny) -> ()) {
+    use pyo3::Python;
     let gil = Python::acquire_gil();
     let py = gil.python();
     check(py.eval(python_code_string, None, None).unwrap())

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -17,7 +17,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
         } else {
             #[allow(unsafe_code)]
             unsafe {
-                unreachable::unreachable()
+                std::hint::unreachable_unchecked()
             }
         }
     }
@@ -29,7 +29,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
         } else {
             #[allow(unsafe_code)]
             unsafe {
-                unreachable::unreachable()
+                std::hint::unreachable_unchecked()
             }
         }
     }
@@ -41,7 +41,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
         } else {
             #[allow(unsafe_code)]
             unsafe {
-                unreachable::unreachable()
+                std::hint::unreachable_unchecked()
             }
         }
     }

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -1,5 +1,5 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType},
+    json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
     RustType, ThreadSafeJsonType,
 };
 
@@ -8,6 +8,8 @@ impl Into<RustType> for serde_json::Value {
         self.to_rust_type()
     }
 }
+
+impl ToRustType for serde_json::Value {}
 
 impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json::Value> {
     #[must_use]

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -1,5 +1,5 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType},
+    json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
     RustType, ThreadSafeJsonType,
 };
 
@@ -8,6 +8,8 @@ impl Into<RustType> for serde_yaml::Value {
         self.to_rust_type()
     }
 }
+
+impl ToRustType for serde_yaml::Value {}
 
 impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml::Value> {
     #[must_use]

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -17,7 +17,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
         } else {
             #[allow(unsafe_code)]
             unsafe {
-                unreachable::unreachable()
+                std::hint::unreachable_unchecked()
             }
         }
     }
@@ -29,7 +29,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
         } else {
             #[allow(unsafe_code)]
             unsafe {
-                unreachable::unreachable()
+                std::hint::unreachable_unchecked()
             }
         }
     }
@@ -41,7 +41,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
         } else {
             #[allow(unsafe_code)]
             unsafe {
-                unreachable::unreachable()
+                std::hint::unreachable_unchecked()
             }
         }
     }


### PR DESCRIPTION
The goal of this PR is to extract the `to_rust_type` functionality into an external trait such that functions that require such property will have a simpler way of defining the generic type.