### PR TITLE
Simplify json type trait

### DIFF
--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -1,4 +1,4 @@
-use crate::{fragment::fragment_components_from_fragment, Error, RustType};
+use crate::{error::Error, fragment::fragment_components_from_fragment, rust_type::RustType};
 use std::{collections::HashMap, convert::TryFrom, fmt::Debug, ops::Deref};
 
 #[allow(clippy::module_name_repetitions)]

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -106,7 +106,7 @@ impl ToRustType for RustType {
     }
 }
 
-impl JsonType<RustType> for RustType {
+impl JsonType for RustType {
     #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if let Self::List(v) = self {
@@ -153,10 +153,7 @@ impl JsonType<RustType> for RustType {
     }
 
     #[must_use]
-    fn as_object(&self) -> Option<JsonMap<Self>>
-    where
-        for<'json> JsonMap<'json, Self>: JsonMapTrait<'json, Self>,
-    {
+    fn as_object(&self) -> Option<JsonMap<Self>> {
         if let Self::Object(_) = self {
             Some(JsonMap::new(self))
         } else {
@@ -192,7 +189,7 @@ impl JsonType<RustType> for RustType {
     }
 }
 
-impl ThreadSafeJsonType<RustType> for RustType {}
+impl ThreadSafeJsonType for RustType {}
 
 impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
     #[must_use]
@@ -282,10 +279,8 @@ mod smoke_test {
 
 #[cfg(test)]
 mod json_map_tests {
-    use crate::{
-        json_type::{JsonMapTrait, JsonType},
-        RustType,
-    };
+    use super::RustType;
+    use crate::json_type::{JsonMapTrait, JsonType};
 
     lazy_static! {
         static ref TESTING_MAP: RustType = rust_type_map!(

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -29,7 +29,7 @@ impl<'json> JsonMapTrait<'json, json::JsonValue> for JsonMap<'json, json::JsonVa
     }
 }
 
-impl JsonType<json::JsonValue> for json::JsonValue {
+impl JsonType for json::JsonValue {
     #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if self.is_array() {
@@ -112,7 +112,7 @@ impl JsonType<json::JsonValue> for json::JsonValue {
     }
 }
 
-impl dyn ThreadSafeJsonType<json::JsonValue> {}
+impl ThreadSafeJsonType for json::JsonValue {}
 
 #[cfg(test)]
 mod tests_json_map_trait {

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -1,6 +1,6 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
-    RustType, ThreadSafeJsonType,
+    json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
+    rust_type::RustType,
 };
 use std::ops::Index;
 

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -1,6 +1,6 @@
 use crate::{
     json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
-    RustType,
+    rust_type::RustType,
 };
 use pyo3::{
     types::{PyAny, PyDict, PySequence},

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -42,7 +42,7 @@ impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
     }
 }
 
-impl JsonType<PyAny> for PyAny {
+impl JsonType for PyAny {
     #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         match PyTryInto::<PySequence>::try_into(self) {

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -1,6 +1,6 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
-    RustType, ThreadSafeJsonType,
+    json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
+    rust_type::RustType,
 };
 
 impl Into<RustType> for serde_json::Value {

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -49,7 +49,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 }
 
-impl JsonType<serde_json::Value> for serde_json::Value {
+impl JsonType for serde_json::Value {
     #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_array() {
@@ -116,7 +116,7 @@ impl JsonType<serde_json::Value> for serde_json::Value {
     }
 }
 
-impl dyn ThreadSafeJsonType<serde_json::Value> {}
+impl ThreadSafeJsonType for serde_json::Value {}
 
 #[cfg(test)]
 mod tests_json_map_trait {

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -1,6 +1,6 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
-    RustType, ThreadSafeJsonType,
+    json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
+    rust_type::RustType,
 };
 
 impl Into<RustType> for serde_yaml::Value {

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -49,7 +49,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 }
 
-impl JsonType<serde_yaml::Value> for serde_yaml::Value {
+impl JsonType for serde_yaml::Value {
     #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_sequence() {
@@ -116,7 +116,7 @@ impl JsonType<serde_yaml::Value> for serde_yaml::Value {
     }
 }
 
-impl dyn ThreadSafeJsonType<serde_yaml::Value> {}
+impl ThreadSafeJsonType for serde_yaml::Value {}
 
 #[cfg(test)]
 mod tests_yaml_map_trait {


### PR DESCRIPTION
Implement further simplifications on the `JsonType` trait definition.

The main purpose is to allow generic methods depending on `JsonType` to move from something like
```rust
fn foo<T: JsonType<T> + Into<RustType> + ToRustType>(_: &T) {}
```
into something like
```rust
fn foo<T: JsonType>(_: &T) {}
```
which is much more human friendly

WARNING: This change removes the guarantee that types implementing `JsonType` trait implement `Into<RustType>` trait as well.
Sadly this is not enforced as we would get back to a not nice signature ;(

The repository does ensure that types have `Into<RustType>` implemented for all the types implementing the trait and `JsonType` implies`ToRustType` which does still allow similar feature of `Into<RustType>`.