### PR TITLE
Update grcov configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /**/*.rs.bk
 /.coverage/
 /.idea/
+/.vscode/
 /Cargo.lock
 /codecov.bash
 /target/

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ ${CODECOV_DIR}/codecov.bash:
 
 .PHONY: coverage
 coverage: export CARGO_INCREMENTAL := 0
-coverage: export RUSTFLAGS := ${RUSTFLAGS} -Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads
+coverage: export RUSTFLAGS := ${RUSTFLAGS} -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads
 coverage: clean-coverage ${CODECOV_DIR}/codecov.bash
 	@command -v grcov @> /dev/null || (echo "grcov is not yet installed" && cargo install grcov)
 	mkdir --parent ${CURDIR}/.coverage


### PR DESCRIPTION
The goal of this PR is to increase the coverage report.
Apparently inline-threshold does not really work but opt-level does a good job.
The new coverage report will ensure that code is not inlining function calls and that TypeWrapping patters is not inlining the "value" extraction

