### PR TITLE
Clippy configurations are in code instead of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ bump-submodules:
 .PHONY: clippy
 clippy:
 	touch src/lib.rs   # touch a file of the rust project to "force" cargo to recompile it so clippy will actually run
-	cargo +${RUST_TOOLCHAIN} clippy --all-targets ${CARGO_ARGS} -- -D clippy::pedantic -D clippy::nursery
+	cargo +${RUST_TOOLCHAIN} clippy --all-targets ${CARGO_ARGS}
 
 .PHONY: clippy-all-flavours
 clippy-all-flavours:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
     unused_variables,
     warnings,
 )]
+// Enable very pendantic clippy linting
+#![deny(clippy::pedantic, clippy::nursery)]
 // Used by json_type_rs::json_type::JsonMapTrait default implementation by json_type_rs::json_type::JsonMap
 // This is mostly needed to reduce the amount of trait constraints when using json_type_rs::json_type::JsonType
 #![feature(specialization)]


### PR DESCRIPTION
^

This allows users to simply run `cargo clippy` which is much easier to remember as well as easier to integrate into IDEs