### PR TITLE
Improve macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy`
     #   * `curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/rustfmt`
     # to validate that both tools are available
-    rust: nightly-2020-04-10
+    rust: nightly-2020-04-23
     env: MAKE_TARGET=lint
 
 install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ test-case = "0"
 
 [dependencies]
 failure = "0"
+join-lazy-fmt = "0"
 json = { version = "0", optional = true }
 pyo3 = { version = "0", optional = true }
 serde_json = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ trait_pyo3 = ["pyo3"]
 [dev-dependencies]
 lazy_static = "1"
 serde_json = "1"
-test-case = "0"
+test-case = "1"
 
 [dependencies]
 failure = "0"

--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -273,23 +273,16 @@ mod tests {
         let _: Option<Box<dyn JsonType>> = None;
     }
 
-    #[test_case("", &Some(rust_type_map!["key" => rust_type_map!["inner_key" => rust_type_vec![1, "2"]]]))]
-    #[test_case("/key", &Some(rust_type_map!["inner_key" => rust_type_vec![1, "2"]]))]
-    #[test_case("/key/inner_key", &Some(rust_type_vec![1,"2"]))]
+    #[test_case("", &Some(rust_type!({"key": {"inner_key": [1, "2"]}})))]
+    #[test_case("/key", &Some(rust_type!({"inner_key": [1, "2"]})))]
+    #[test_case("/key/inner_key", &Some(rust_type!([1,"2"])))]
     #[test_case("/key/inner_key/0", &Some(RustType::from(1)))]
     #[test_case("/key/inner_key/1", &Some(RustType::from("2")))]
     #[test_case("/not_present", &None)]
     #[test_case("/key/inner_key/a", &None)]
     #[test_case("/key/inner_key/2", &None)]
     fn test_get_fragment(fragment: &str, expected_value: &Option<RustType>) {
-        let external_map = rust_type_map![
-            "key" => rust_type_map![
-                "inner_key" => rust_type_vec![
-                    1,
-                    "2"
-                ],
-            ],
-        ];
+        let external_map = rust_type!({"key": {"inner_key": [1, "2"]}});
         assert_eq!(get_fragment(&external_map, fragment), expected_value.as_ref());
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,29 +30,3 @@ macro_rules! rust_type_vec {
         RustType::from(thing)
     }};
 }
-
-#[cfg(feature = "trait_json")]
-#[macro_export]
-macro_rules! rust_json {
-    ($($json:tt)+) => {{
-        use serde_json;
-        use json;
-        let thing: json::JsonValue = json::parse(
-            serde_json::to_string(&json![$($json)+]).unwrap().as_str(),
-        ).unwrap();
-        thing
-    }};
-}
-
-#[cfg(feature = "trait_serde_yaml")]
-#[macro_export]
-macro_rules! yaml {
-    ($($json:tt)+) => {{
-        use serde_json;
-        use serde_yaml;
-        let thing: serde_yaml::Value = serde_yaml::from_str(
-            serde_json::to_string(&json![$($json)+]).unwrap().as_str(),
-        ).unwrap();
-        thing
-    }};
-}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,32 +1,284 @@
 #[macro_export]
-macro_rules! rust_type_map {
-    ($($k:expr => $v: expr),*,) => {{
-        rust_type_map![$($k => $v),*]
-    }};
-    ($($k: expr => $v: expr),*) => {{
-        use $crate::RustType;
-        use std::collections::hash_map::HashMap;
+macro_rules! rust_type {
+    // Disclaimer: This TT muncher is a slightly modified version of the json! macro
+    // provied by the serde-json crate (https://github.com/serde-rs/).
+    // Thanks to @dtolnay
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: rust_type!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
 
-        // Variable definition is needed to ensure that the resulting type is known in the context
-        #[allow(unused_mut)]
-        let mut thing: HashMap<String, RustType> = HashMap::default();
-        $( let _ = thing.insert($k.to_string(), RustType::from($v)); )*
-        RustType::from(thing)
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        rust_type!(@array [$($elems,)* rust_type!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        rust_type!(@array [$($elems,)* rust_type!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        rust_type!(@array [$($elems,)* rust_type!(false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        rust_type!(@array [$($elems,)* rust_type!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        rust_type!(@array [$($elems,)* rust_type!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        rust_type!(@array [$($elems,)* rust_type!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        rust_type!(@array [$($elems,)* rust_type!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        rust_type!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        compile_error!(concat!("unexpected", stringify!($unexpected)));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: rust_type!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        rust_type!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        compile_error!(concat!("unexpected", stringify!($unexpected)));
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        rust_type!(@object $object [$($key)+] (rust_type!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        rust_type!(@object $object [$($key)+] (rust_type!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        rust_type!(@object $object [$($key)+] (rust_type!(false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        rust_type!(@object $object [$($key)+] (rust_type!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        rust_type!(@object $object [$($key)+] (rust_type!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        rust_type!(@object $object [$($key)+] (rust_type!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        rust_type!(@object $object [$($key)+] (rust_type!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        compile_error!("Unexpected end of the json Object (missing the value)")
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        compile_error!("Unexpected end of the json Object (missing column and value)")
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        json_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        json_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        rust_type!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        rust_type!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: rust_type!($($json)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    (null) => {
+        $crate::RustType::Null
+    };
+
+    (true) => {
+        $crate::RustType::Boolean(true)
+    };
+
+    (false) => {
+        $crate::RustType::Boolean(false)
+    };
+
+    ([]) => {
+        $crate::RustType::List(Vec::with_capacity(0))
+    };
+
+    ([ $($tt:tt)+ ]) => {
+        $crate::RustType::List(rust_type!(@array [] $($tt)+))
+    };
+
+    ({}) => {
+        $crate::RustType::Object(::std::collections::HashMap::with_capacity(0))
+    };
+
+    ({ $($tt:tt)+ }) => {
+        $crate::RustType::Object({
+            let mut object = ::std::collections::HashMap::new();
+            rust_type!(@object object () ($($tt)+) ($($tt)+));
+            object
+        })
+    };
+
+    // Any Into<RustType> type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($other:expr) => {{
+        let val: $crate::RustType = $other.into();
+        val
     }};
 }
 
-#[macro_export]
-macro_rules! rust_type_vec {
-    ($($item: expr),*,) => {{
-        rust_type_vec![$($item),*]
-    }};
-    ($($item: expr),*) => {{
-        use $crate::RustType;
+#[cfg(test)]
+mod tests {
+    use crate::rust_type::RustType;
+    use std::collections::HashMap;
+    use test_case::test_case;
 
-        // Variable definition is needed to ensure that the resulting type is known in the context
-        let thing: Vec<RustType> = vec![
-            $( RustType::from($item), )*
-        ];
-        RustType::from(thing)
-    }};
+    #[test_case(rust_type!(null)  => RustType::Null)]
+    #[test_case(rust_type!(1)     => RustType::Integer(1))]
+    #[test_case(rust_type!(2.3)   => RustType::Number(2.3))]
+    #[test_case(rust_type!("4")   => RustType::String("4".to_string()))]
+    #[test_case(rust_type!(true)  => RustType::Boolean(true))]
+    #[test_case(rust_type!(false) => RustType::Boolean(false))]
+    #[test_case(rust_type!([])    => RustType::List(Vec::new()))]
+    #[test_case(rust_type!({})    => RustType::Object(HashMap::new()))]
+    // Test not empty lists
+    #[test_case(rust_type!([null]) => RustType::List(vec![RustType::Null]))]
+    #[test_case(
+        rust_type!([{"k": 6}, [5], {}, [], false, true, "4", 2.3, 1, null]) => RustType::List(vec![
+            RustType::Object({
+                let mut map = HashMap::new();
+                let _ = map.insert("k".to_string(), RustType::Integer(6));
+                map
+            }),
+            RustType::List(vec![RustType::Integer(5)]),
+            RustType::Object(HashMap::new()),
+            RustType::List(Vec::new()),
+            RustType::Boolean(false),
+            RustType::Boolean(true),
+            RustType::String("4".to_string()),
+            RustType::Number(2.3),
+            RustType::Integer(1),
+            RustType::Null,
+        ])
+    )]
+    // Test not empty maps
+    #[test_case(
+        rust_type!({
+            "{\"k\":6}": {"k": 6},
+            "[5]": [5],
+            "{}": {},
+            "[]": [],
+            "false": false,
+            "true": true,
+            "4": "4",
+            "2.3": 2.3,
+            "1": 1,
+            "null": null
+        }) => RustType::Object([
+            ("{\"k\":6}".to_string(), RustType::Object({
+                let mut map = HashMap::new();
+                let _ = map.insert("k".to_string(), RustType::Integer(6));
+                map
+            })),
+            ("[5]".to_string(), RustType::List(vec![RustType::Integer(5)])),
+            ("{}".to_string(), RustType::Object(HashMap::new())),
+            ("[]".to_string(), RustType::List(Vec::new())),
+            ("false".to_string(), RustType::Boolean(false)),
+            ("true".to_string(), RustType::Boolean(true)),
+            ("4".to_string(), RustType::String("4".to_string())),
+            ("2.3".to_string(), RustType::Number(2.3)),
+            ("1".to_string(), RustType::Integer(1)),
+            ("null".to_string(), RustType::Null),
+        ].iter().cloned().collect())
+    )]
+    #[test_case(
+        rust_type!({"null": null}) => RustType::Object([
+            ("null".to_string(), RustType::Null)
+        ].iter().cloned().collect())
+    )]
+    const fn test_ensure_macro_is_consistent(value: RustType) -> RustType {
+        value
+    }
 }

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -194,7 +194,10 @@ impl ThreadSafeJsonType for RustType {}
 impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
     #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &RustType)> + 'json> {
-        if let RustType::Object(hash_map) = self.deref() {
+        if let RustType::Object(hash_map) = {
+            #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &RustType is retrieved from JsonMap
+            &self.deref()
+        } {
             Box::new(hash_map.iter().map(|(k, v)| (k.as_str(), v)))
         } else {
             #[allow(unsafe_code)]

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -240,13 +240,12 @@ mod smoke_test {
     use std::collections::hash_map::HashMap;
     use test_case::test_case;
 
-    #[test_case(&RustType::from(())  => "null")]
-    #[test_case(&RustType::from(true)  => "true")]
-    #[test_case(&RustType::from(false)  => "false")]
-    #[test_case(&RustType::from(1)  => "1")]
-    #[test_case(&RustType::from(2.3)  => "2.3")]
-    #[test_case(&rust_type_vec![1, 2.3, false]  => "[1,2.3,false]")]
-    #[test_case(&rust_type_map!["key" => "value", "array" => rust_type_vec![rust_type_map!["k"=>"v"]]]  => r#"{"array":[{"k":"v"}],"key":"value"}"#)]
+    #[test_case(&rust_type!(()) => "null")]
+    #[test_case(&rust_type!(true) => "true")]
+    #[test_case(&rust_type!(false) => "false")]
+    #[test_case(&rust_type!(1) => "1")]
+    #[test_case(&rust_type!(2.3) => "2.3")]
+    #[test_case(&rust_type!([1, 2.3, false]) => "[1,2.3,false]")]
     fn test_to_string(value: &RustType) -> String {
         value.to_string()
     }
@@ -321,11 +320,7 @@ mod json_map_tests {
     use crate::json_type::{JsonMapTrait, JsonType};
 
     lazy_static! {
-        static ref TESTING_MAP: RustType = rust_type_map!(
-            "key1" => rust_type_map!(
-                "key2" => 1,
-            ),
-        );
+        static ref TESTING_MAP: RustType = rust_type!({"key1": {"key2": 1}});
     }
 
     #[test]

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -112,6 +112,18 @@ impl JsonType for json::JsonValue {
 impl ThreadSafeJsonType for json::JsonValue {}
 
 #[cfg(test)]
+macro_rules! rust_json {
+    ($($json:tt)+) => {{
+        use serde_json;
+        use json;
+        let thing: json::JsonValue = json::parse(
+            serde_json::to_string(&json![$($json)+]).unwrap().as_str(),
+        ).unwrap();
+        thing
+    }};
+}
+
+#[cfg(test)]
 mod tests_json_map_trait {
     use crate::{json_type::JsonMap, JsonMapTrait};
 

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -159,6 +159,7 @@ mod tests_json_map_trait {
 #[cfg(test)]
 mod tests_primitive_type_trait {
     use crate::json_type::{JsonType, PrimitiveType};
+    use std::ops::Deref;
     use test_case::test_case;
 
     #[test_case(&rust_json![[]], PrimitiveType::Array)]
@@ -306,11 +307,12 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1.2], &None)]
     #[test_case(&rust_json![{"1": 1}], &Some(rust_json![{"1": 1}]))]
     fn test_as_object(value: &json::JsonValue, expected_value: &Option<json::JsonValue>) {
-        use std::ops::Deref;
-
         assert_eq!(
             match JsonType::as_object(value) {
-                Some(ref v) => Some(v.deref()),
+                Some(ref v) => {
+                    #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &json::JsonValue is retrieved from JsonMap
+                    Some(v.deref())
+                }
                 None => None,
             },
             expected_value.as_ref(),

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -19,7 +19,10 @@ impl ToRustType for PyAny {}
 impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
     #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
-        match PyTryInto::<PyDict>::try_into(self.deref()) {
+        match PyTryInto::<PyDict>::try_into({
+            #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &PyAny is retrieved from JsonMap
+            self.deref()
+        }) {
             Ok(python_dict) => Box::new(python_dict.iter().filter_map(|(k, _)| k.as_string())),
             Err(_) => Box::new(Vec::with_capacity(0).into_iter()),
         }
@@ -27,7 +30,10 @@ impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
 
     #[must_use]
     fn values(&'json self) -> Box<dyn Iterator<Item = &PyAny> + 'json> {
-        match PyTryInto::<PyDict>::try_into(self.deref()) {
+        match PyTryInto::<PyDict>::try_into({
+            #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &PyAny is retrieved from JsonMap
+            self.deref()
+        }) {
             Ok(python_dict) => Box::new(python_dict.iter().map(|(_, v)| v)),
             Err(_) => Box::new(Vec::with_capacity(0).into_iter()),
         }
@@ -35,7 +41,10 @@ impl<'json> JsonMapTrait<'json, PyAny> for JsonMap<'json, PyAny> {
 
     #[must_use]
     fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &PyAny)> + 'json> {
-        match PyTryInto::<PyDict>::try_into(self.deref()) {
+        match PyTryInto::<PyDict>::try_into({
+            #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &PyAny is retrieved from JsonMap
+            self.deref()
+        }) {
             Ok(python_dict) => Box::new(python_dict.iter().filter_map(|(k, v)| k.as_string().map(|k_string| (k_string, v)).or(None))),
             Err(_) => Box::new(Vec::with_capacity(0).into_iter()),
         }

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -145,6 +145,7 @@ mod tests_json_map_trait {
 #[cfg(test)]
 mod tests_primitive_type_trait {
     use crate::json_type::{JsonType, PrimitiveType};
+    use std::ops::Deref;
     use test_case::test_case;
 
     #[test_case(&json![[]], PrimitiveType::Array)]
@@ -292,11 +293,12 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1.2], &None)]
     #[test_case(&json![{"1": 1}], &Some(json![{"1": 1}]))]
     fn test_as_object(value: &serde_json::Value, expected_value: &Option<serde_json::Value>) {
-        use std::ops::Deref;
-
         assert_eq!(
             match JsonType::as_object(value) {
-                Some(ref v) => Some(v.deref()),
+                Some(ref v) => Some({
+                    #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &serde_json::Value is retrieved from JsonMap
+                    v.deref()
+                }),
                 None => None,
             },
             expected_value.as_ref(),

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -157,6 +157,7 @@ mod tests_yaml_map_trait {
 #[cfg(test)]
 mod tests_primitive_type_trait {
     use crate::json_type::{JsonType, PrimitiveType};
+    use std::ops::Deref;
     use test_case::test_case;
 
     #[test_case(&yaml![[]], PrimitiveType::Array)]
@@ -304,11 +305,12 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1.2], &None)]
     #[test_case(&yaml![{"1": 1}], &Some(yaml![{"1": 1}]))]
     fn test_as_object(value: &serde_yaml::Value, expected_value: &Option<serde_yaml::Value>) {
-        use std::ops::Deref;
-
         assert_eq!(
             match JsonType::as_object(value) {
-                Some(ref v) => Some(v.deref()),
+                Some(ref v) => Some({
+                    #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &serde_yaml::Value is retrieved from JsonMap
+                    v.deref()
+                }),
                 None => None,
             },
             expected_value.as_ref(),

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -116,6 +116,18 @@ impl JsonType for serde_yaml::Value {
 impl ThreadSafeJsonType for serde_yaml::Value {}
 
 #[cfg(test)]
+macro_rules! yaml {
+    ($($json:tt)+) => {{
+        use serde_json;
+        use serde_yaml;
+        let thing: serde_yaml::Value = serde_yaml::from_str(
+            serde_json::to_string(&json![$($json)+]).unwrap().as_str(),
+        ).unwrap();
+        thing
+    }};
+}
+
+#[cfg(test)]
 mod tests_yaml_map_trait {
     use crate::json_type::{JsonMap, JsonMapTrait};
 


### PR DESCRIPTION
This PR removes the "ugly" and un-friendly `rust_type_map`, `rust_type_vec` macros and adds a more friendly `rust_type` one. The new macro allow a the usage of valid JSON content as macro argument.

RustType now implements Display trait and consequently ToString as well
