### PR TITLE
Rename internal rust_type module to avoid clash with rust_type macro

### DIFF
--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -1,4 +1,4 @@
-use crate::{error::Error, fragment_helpers::fragment_components_from_fragment, rust_type::RustType};
+use crate::{error::Error, fragment_helpers::fragment_components_from_fragment, rust_type_impl::RustType};
 use std::{collections::HashMap, convert::TryFrom, fmt::Debug, ops::Deref};
 
 #[allow(clippy::module_name_repetitions)]
@@ -232,7 +232,7 @@ pub fn get_fragment<'json, T: JsonType>(json_object: &'json T, fragment: &str) -
 #[cfg(test)]
 mod tests {
     use super::{get_fragment, Error, JsonType, PrimitiveType};
-    use crate::rust_type::RustType;
+    use crate::rust_type_impl::RustType;
     use std::convert::TryFrom;
     use test_case::test_case;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,11 +58,11 @@ pub mod macros;
 mod error;
 pub mod fragment_helpers;
 mod json_type;
-mod rust_type;
+mod rust_type_impl;
 pub mod traits;
 
 pub use crate::{
     error::Error,
     json_type::{get_fragment, JsonMap, JsonMapTrait, JsonType, PrimitiveType, ThreadSafeJsonType, ToRustType},
-    rust_type::RustType,
+    rust_type_impl::RustType,
 };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -211,7 +211,7 @@ macro_rules! rust_type {
 
 #[cfg(test)]
 mod tests {
-    use crate::rust_type::RustType;
+    use crate::rust_type_impl::RustType;
     use std::collections::HashMap;
     use test_case::test_case;
 

--- a/src/rust_type_impl.rs
+++ b/src/rust_type_impl.rs
@@ -235,7 +235,7 @@ impl<'json> JsonMapTrait<'json, RustType> for JsonMap<'json, RustType> {
 mod smoke_test {
     use crate::{
         json_type::{JsonMapTrait, JsonType},
-        rust_type::RustType,
+        rust_type_impl::RustType,
     };
     use std::collections::hash_map::HashMap;
     use test_case::test_case;

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -1,6 +1,6 @@
 use crate::{
     json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
-    rust_type::RustType,
+    rust_type_impl::RustType,
 };
 use std::ops::Index;
 

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -1,6 +1,6 @@
 use crate::{
     json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
-    rust_type::RustType,
+    rust_type_impl::RustType,
 };
 use pyo3::{
     types::{PyAny, PyDict, PySequence},

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -1,6 +1,6 @@
 use crate::{
     json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
-    rust_type::RustType,
+    rust_type_impl::RustType,
 };
 
 impl Into<RustType> for serde_json::Value {

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -1,6 +1,6 @@
 use crate::{
     json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
-    rust_type::RustType,
+    rust_type_impl::RustType,
 };
 
 impl Into<RustType> for serde_yaml::Value {


### PR DESCRIPTION
The internal `rust_type` module makes impossible to import the `rust_type` macro (especially in rust 2018 version).

In order to address the issue, as `rust_type` module is private I'm just renaming it into `rust_type_impl` ;)