### PR TITLE
Define json type to string trait

### DIFF
--- a/src/json_type.rs
+++ b/src/json_type.rs
@@ -84,10 +84,15 @@ pub trait ToRustType {
     }
 }
 
+#[allow(clippy::module_name_repetitions)]
+pub trait JsonTypeToString {
+    fn to_json_string(&self) -> String;
+}
+
 // This trait allows us to have a 1:1 mapping with serde_json, generally used by rust libraries
 // but gives us the power to use different objects from serde_json. This gives us the ability
 // to support usage of different data-types like PyObject from pyo3 in case of python bindings
-pub trait JsonType: Debug + ToRustType {
+pub trait JsonType: JsonTypeToString + ToRustType {
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>>
     where
         Self: Sized;
@@ -211,6 +216,12 @@ impl<'json, T: JsonType> JsonMapTrait<'json, T> for JsonMap<'json, T> {
     #[must_use]
     default fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &T)>> {
         todo!("The library relies on specialization to reduce the amount of trait constraints needed for JsonType. That's why we have this dummy JsonMapTrait::items implementation. NOTE: All the types implementing JsonType trait should take care of implementing at least JsonMapTrait::items as well.")
+    }
+}
+
+impl<T: JsonType> JsonTypeToString for T {
+    default fn to_json_string(&self) -> String {
+        self.to_rust_type().to_json_string()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,6 @@ pub mod traits;
 
 pub use crate::{
     error::Error,
-    json_type::{get_fragment, JsonMap, JsonMapTrait, JsonType, PrimitiveType, ThreadSafeJsonType, ToRustType},
+    json_type::{get_fragment, JsonMap, JsonMapTrait, JsonType, JsonTypeToString, PrimitiveType, ThreadSafeJsonType, ToRustType},
     rust_type_impl::RustType,
 };

--- a/src/rust_type_impl.rs
+++ b/src/rust_type_impl.rs
@@ -315,7 +315,7 @@ mod smoke_test {
 }
 
 #[cfg(test)]
-mod json_map_tests {
+mod tests_json_map {
     use super::RustType;
     use crate::json_type::{JsonMapTrait, JsonType};
 

--- a/src/rust_type_impl.rs
+++ b/src/rust_type_impl.rs
@@ -1,5 +1,5 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
+    json_type::{JsonMap, JsonMapTrait, JsonType, JsonTypeToString, ToRustType},
     ThreadSafeJsonType,
 };
 use join_lazy_fmt::Join;
@@ -36,6 +36,12 @@ impl fmt::Display for RustType {
                 write!(formatter, "}}")
             }
         }
+    }
+}
+
+impl JsonTypeToString for RustType {
+    fn to_json_string(&self) -> String {
+        self.to_string()
     }
 }
 
@@ -344,6 +350,28 @@ mod tests_json_map {
         assert_eq!(
             JsonType::as_object(key1).unwrap().items().map(|(k, v)| format!("{} -> {:?}", k, v)).collect::<Vec<_>>(),
             vec![format!("key2 -> {:?}", RustType::from(1))],
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests_to_json_string {
+    use crate::json_type::JsonTypeToString;
+
+    #[test]
+    fn smoke_test() {
+        let value = rust_type![[
+            {"array": []},
+            {"boolean": false},
+            {"float": 2.3},
+            {"integer": 1},
+            {"null": null},
+            {"object": {}},
+            {"string": "string"},
+        ]];
+        assert_eq!(
+            value.to_json_string(),
+            r#"[{"array":[]},{"boolean":false},{"float":2.3},{"integer":1},{"null":null},{"object":{}},{"string":"string"}]"#
         );
     }
 }

--- a/src/traits/_json.rs
+++ b/src/traits/_json.rs
@@ -2,34 +2,35 @@ use crate::{
     json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
     rust_type_impl::RustType,
 };
+use json::JsonValue;
 use std::ops::Index;
 
-impl Into<RustType> for json::JsonValue {
+impl Into<RustType> for JsonValue {
     fn into(self) -> RustType {
         self.to_rust_type()
     }
 }
 
-impl ToRustType for json::JsonValue {}
+impl ToRustType for JsonValue {}
 
-impl<'json> JsonMapTrait<'json, json::JsonValue> for JsonMap<'json, json::JsonValue> {
+impl<'json> JsonMapTrait<'json, JsonValue> for JsonMap<'json, JsonValue> {
     #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         Box::new(self.entries().map(|(key, _)| key))
     }
 
     #[must_use]
-    fn values(&'json self) -> Box<dyn Iterator<Item = &json::JsonValue> + 'json> {
+    fn values(&'json self) -> Box<dyn Iterator<Item = &JsonValue> + 'json> {
         Box::new(self.entries().map(|(_, value)| value))
     }
 
     #[must_use]
-    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &json::JsonValue)> + 'json> {
+    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &JsonValue)> + 'json> {
         Box::new(self.entries())
     }
 }
 
-impl JsonType for json::JsonValue {
+impl JsonType for JsonValue {
     #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if self.is_array() {
@@ -109,14 +110,14 @@ impl JsonType for json::JsonValue {
     }
 }
 
-impl ThreadSafeJsonType for json::JsonValue {}
+impl ThreadSafeJsonType for JsonValue {}
 
 #[cfg(test)]
 macro_rules! rust_json {
     ($($json:tt)+) => {{
         use serde_json;
         use json;
-        let thing: json::JsonValue = json::parse(
+        let thing: JsonValue = json::parse(
             serde_json::to_string(&json![$($json)+]).unwrap().as_str(),
         ).unwrap();
         thing
@@ -125,33 +126,31 @@ macro_rules! rust_json {
 
 #[cfg(test)]
 mod tests_json_map_trait {
-    use crate::{json_type::JsonMap, JsonMapTrait};
+    use crate::json_type::{JsonMap, JsonMapTrait};
+    use json::JsonValue;
 
     lazy_static! {
-        static ref TESTING_MAP: json::JsonValue = rust_json![{"k1": "v1", "k2": "v2"}];
+        static ref TESTING_MAP: JsonValue = rust_json![{"k1": "v1", "k2": "v2"}];
     }
 
     #[test]
     fn keys() {
-        let testing_map: &json::JsonValue = &TESTING_MAP;
+        let testing_map: &JsonValue = &TESTING_MAP;
         assert_eq!(JsonMap::new(testing_map).keys().collect::<Vec<_>>(), vec!["k1", "k2"]);
     }
 
     #[test]
     fn values() {
-        let testing_map: &json::JsonValue = &TESTING_MAP;
-        assert_eq!(
-            JsonMap::new(testing_map).values().collect::<Vec<_>>(),
-            vec![&json::JsonValue::from("v1"), &json::JsonValue::from("v2")]
-        );
+        let testing_map: &JsonValue = &TESTING_MAP;
+        assert_eq!(JsonMap::new(testing_map).values().collect::<Vec<_>>(), vec![&JsonValue::from("v1"), &JsonValue::from("v2")]);
     }
 
     #[test]
     fn items() {
-        let testing_map: &json::JsonValue = &TESTING_MAP;
+        let testing_map: &JsonValue = &TESTING_MAP;
         assert_eq!(
             JsonMap::new(testing_map).items().collect::<Vec<_>>(),
-            vec![("k1", &json::JsonValue::from("v1")), ("k2", &json::JsonValue::from("v2"))]
+            vec![("k1", &JsonValue::from("v1")), ("k2", &JsonValue::from("v2"))]
         );
     }
 }
@@ -159,6 +158,7 @@ mod tests_json_map_trait {
 #[cfg(test)]
 mod tests_primitive_type_trait {
     use crate::json_type::{JsonType, PrimitiveType};
+    use json::JsonValue;
     use std::ops::Deref;
     use test_case::test_case;
 
@@ -169,26 +169,26 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1.2], PrimitiveType::Number)]
     #[test_case(&rust_json![{"prop": "value"}], PrimitiveType::Object)]
     #[test_case(&rust_json!["string"], PrimitiveType::String)]
-    fn test_primitive_type(value: &json::JsonValue, expected_value: PrimitiveType) {
+    fn test_primitive_type(value: &JsonValue, expected_value: PrimitiveType) {
         assert_eq!(JsonType::primitive_type(value), expected_value);
     }
 
     #[test_case(&rust_json![{"present": 1}], "present", &Some(rust_json![1]))]
     #[test_case(&rust_json![{"present": 1}], "not-present", &None)]
-    fn test_get_attribute(value: &json::JsonValue, attribute_name: &str, expected_value: &Option<json::JsonValue>) {
+    fn test_get_attribute(value: &JsonValue, attribute_name: &str, expected_value: &Option<JsonValue>) {
         assert_eq!(JsonType::get_attribute(value, attribute_name), expected_value.as_ref());
     }
 
     #[test_case(&rust_json![[0, 1, 2]], 1, &Some(rust_json![1]))]
     #[test_case(&rust_json![[0, 1, 2]], 4, &None)]
-    fn test_get_index(value: &json::JsonValue, index: usize, expected_value: &Option<json::JsonValue>) {
+    fn test_get_index(value: &JsonValue, index: usize, expected_value: &Option<JsonValue>) {
         assert_eq!(JsonType::get_index(value, index), expected_value.as_ref());
     }
 
     #[test_case(&rust_json![{"present": 1}], "present", true)]
     #[test_case(&rust_json![{"present": 1}], "not-present", false)]
     #[test_case(&rust_json![[1, 2, 3]], "not-present", false)]
-    fn test_has_attribute(value: &json::JsonValue, attr_name: &str, expected_value: bool) {
+    fn test_has_attribute(value: &JsonValue, attr_name: &str, expected_value: bool) {
         assert_eq!(JsonType::has_attribute(value, attr_name), expected_value);
     }
 
@@ -199,7 +199,7 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1.2_f32], false)]
     #[test_case(&rust_json![{"key": "value"}], false)]
     #[test_case(&rust_json!["string"], false)]
-    fn test_is_array(value: &json::JsonValue, expected_value: bool) {
+    fn test_is_array(value: &JsonValue, expected_value: bool) {
         assert_eq!(JsonType::is_array(value), expected_value);
     }
 
@@ -210,7 +210,7 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1.2_f32], false)]
     #[test_case(&rust_json![{"key": "value"}], false)]
     #[test_case(&rust_json!["string"], false)]
-    fn test_is_boolean(value: &json::JsonValue, expected_value: bool) {
+    fn test_is_boolean(value: &JsonValue, expected_value: bool) {
         assert_eq!(JsonType::is_boolean(value), expected_value);
     }
 
@@ -221,7 +221,7 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1.2_f32], false)]
     #[test_case(&rust_json![{"key": "value"}], false)]
     #[test_case(&rust_json!["string"], false)]
-    fn test_is_integer(value: &json::JsonValue, expected_value: bool) {
+    fn test_is_integer(value: &JsonValue, expected_value: bool) {
         assert_eq!(JsonType::is_integer(value), expected_value);
     }
 
@@ -232,7 +232,7 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1.2_f32], false)]
     #[test_case(&rust_json![{"key": "value"}], false)]
     #[test_case(&rust_json!["string"], false)]
-    fn test_is_null(value: &json::JsonValue, expected_value: bool) {
+    fn test_is_null(value: &JsonValue, expected_value: bool) {
         assert_eq!(JsonType::is_null(value), expected_value);
     }
 
@@ -243,7 +243,7 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1.2_f32], true)]
     #[test_case(&rust_json![{"key": "value"}], false)]
     #[test_case(&rust_json!["string"], false)]
-    fn test_is_number(value: &json::JsonValue, expected_value: bool) {
+    fn test_is_number(value: &JsonValue, expected_value: bool) {
         assert_eq!(JsonType::is_number(value), expected_value);
     }
 
@@ -254,7 +254,7 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1.2_f32], false)]
     #[test_case(&rust_json![{"key": "value"}], true)]
     #[test_case(&rust_json!["string"], false)]
-    fn test_is_object(value: &json::JsonValue, expected_value: bool) {
+    fn test_is_object(value: &JsonValue, expected_value: bool) {
         assert_eq!(JsonType::is_object(value), expected_value);
     }
 
@@ -265,52 +265,52 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1.2_f32], false)]
     #[test_case(&rust_json![{"key": "value"}], false)]
     #[test_case(&rust_json!["string"], true)]
-    fn test_is_string(value: &json::JsonValue, expected_value: bool) {
+    fn test_is_string(value: &JsonValue, expected_value: bool) {
         assert_eq!(JsonType::is_string(value), expected_value);
     }
 
     #[test_case(&rust_json![[1]], &Some(vec![rust_json![1]]))]
     #[test_case(&rust_json![[1, "a"]], &Some(vec![rust_json![1], rust_json!["a"]]))]
     #[test_case(&rust_json![null], &None)]
-    fn test_as_array(value: &json::JsonValue, expected_value: &Option<Vec<json::JsonValue>>) {
+    fn test_as_array(value: &JsonValue, expected_value: &Option<Vec<JsonValue>>) {
         assert_eq!(&JsonType::as_array(value).map(|iterator| iterator.cloned().collect()), expected_value);
     }
 
     #[test_case(&rust_json![true], Some(true))]
     #[test_case(&rust_json![false], Some(false))]
     #[test_case(&rust_json![1], None)]
-    fn test_as_boolean(value: &json::JsonValue, expected_value: Option<bool>) {
+    fn test_as_boolean(value: &JsonValue, expected_value: Option<bool>) {
         assert_eq!(JsonType::as_boolean(value), expected_value);
     }
 
     #[test_case(&rust_json![1], Some(1))]
     #[test_case(&rust_json![1.2], None)]
     #[test_case(&rust_json!["1"], None)]
-    fn test_as_integer(value: &json::JsonValue, expected_value: Option<i128>) {
+    fn test_as_integer(value: &JsonValue, expected_value: Option<i128>) {
         assert_eq!(JsonType::as_integer(value), expected_value);
     }
 
     #[test_case(&rust_json![null], Some(()))]
     #[test_case(&rust_json!["1"], None)]
-    fn test_as_null(value: &json::JsonValue, expected_value: Option<()>) {
+    fn test_as_null(value: &JsonValue, expected_value: Option<()>) {
         assert_eq!(JsonType::as_null(value), expected_value);
     }
 
     #[test_case(&rust_json![1], Some(1_f64))]
     #[test_case(&rust_json![1.2], Some(1.2))]
     #[test_case(&rust_json!["1"], None)]
-    fn test_as_number(value: &json::JsonValue, expected_value: Option<f64>) {
+    fn test_as_number(value: &JsonValue, expected_value: Option<f64>) {
         assert_eq!(JsonType::as_number(value), expected_value);
     }
 
     #[test_case(&rust_json![1], &None)]
     #[test_case(&rust_json![1.2], &None)]
     #[test_case(&rust_json![{"1": 1}], &Some(rust_json![{"1": 1}]))]
-    fn test_as_object(value: &json::JsonValue, expected_value: &Option<json::JsonValue>) {
+    fn test_as_object(value: &JsonValue, expected_value: &Option<JsonValue>) {
         assert_eq!(
             match JsonType::as_object(value) {
                 Some(ref v) => {
-                    #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &json::JsonValue is retrieved from JsonMap
+                    #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &JsonValue is retrieved from JsonMap
                     Some(v.deref())
                 }
                 None => None,
@@ -322,17 +322,18 @@ mod tests_primitive_type_trait {
     #[test_case(&rust_json![1], None)]
     #[test_case(&rust_json![1.2], None)]
     #[test_case(&rust_json!["1"], Some("1"))]
-    fn test_as_string(value: &json::JsonValue, expected_value: Option<&str>) {
+    fn test_as_string(value: &JsonValue, expected_value: Option<&str>) {
         assert_eq!(JsonType::as_string(value), expected_value);
     }
 }
 
 #[cfg(test)]
-mod json_map_tests {
+mod tests_json_map {
     use crate::json_type::{JsonMapTrait, JsonType};
+    use json::JsonValue;
 
     lazy_static! {
-        static ref TESTING_MAP: json::JsonValue = rust_json![{"key1": {"key2": 1}}];
+        static ref TESTING_MAP: JsonValue = rust_json![{"key1": {"key2": 1}}];
     }
 
     #[test]
@@ -346,7 +347,7 @@ mod json_map_tests {
         let key1 = TESTING_MAP.get_attribute("key1").unwrap();
         assert_eq!(
             JsonType::as_object(key1).unwrap().values().map(|v| format!("{:?}", v)).collect::<Vec<_>>(),
-            vec![format!("{:?}", json::JsonValue::from(1))],
+            vec![format!("{:?}", JsonValue::from(1))],
         );
     }
 
@@ -355,7 +356,7 @@ mod json_map_tests {
         let key1 = TESTING_MAP.get_attribute("key1").unwrap();
         assert_eq!(
             JsonType::as_object(key1).unwrap().items().map(|(k, v)| format!("{} -> {:?}", k, v)).collect::<Vec<_>>(),
-            vec![format!("key2 -> {:?}", json::JsonValue::from(1))],
+            vec![format!("key2 -> {:?}", JsonValue::from(1))],
         );
     }
 }

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -410,3 +410,28 @@ mod tests_json_map {
         });
     }
 }
+
+#[cfg(test)]
+mod tests_to_json_string {
+    use super::perform_python_check;
+    use crate::json_type::JsonTypeToString;
+
+    #[test]
+    fn smoke_test() {
+        let value_str = r#"[
+            {"array": []},
+            {"boolean": False},
+            {"float": 2.3},
+            {"integer": 1},
+            {"null": None},
+            {"object": {}},
+            {"string": "string"},
+        ]"#;
+        perform_python_check(value_str, |python_object_ref| {
+            assert_eq!(
+                python_object_ref.to_json_string(),
+                r#"[{"array":[]},{"boolean":false},{"float":2.3},{"integer":1},{"null":null},{"object":{}},{"string":"string"}]"#
+            );
+        });
+    }
+}

--- a/src/traits/_pyo3.rs
+++ b/src/traits/_pyo3.rs
@@ -2,6 +2,8 @@ use crate::{
     json_type::{JsonMap, JsonMapTrait, JsonType, ToRustType},
     rust_type_impl::RustType,
 };
+#[cfg(test)]
+use pyo3::Python;
 use pyo3::{
     types::{PyAny, PyDict, PySequence},
     ObjectProtocol, PyTryInto,
@@ -142,7 +144,6 @@ impl JsonType for PyAny {
 
 #[cfg(test)]
 fn perform_python_check(python_code_string: &str, check: impl Fn(&PyAny) -> ()) {
-    use pyo3::Python;
     let gil = Python::acquire_gil();
     let py = gil.python();
     check(py.eval(python_code_string, None, None).unwrap())
@@ -150,7 +151,8 @@ fn perform_python_check(python_code_string: &str, check: impl Fn(&PyAny) -> ()) 
 
 #[cfg(test)]
 mod tests_json_map_trait {
-    use crate::{json_type::JsonMap, traits::_pyo3::perform_python_check, JsonMapTrait};
+    use super::perform_python_check;
+    use crate::json_type::{JsonMap, JsonMapTrait};
     use std::collections::HashSet;
 
     lazy_static! {
@@ -196,10 +198,8 @@ mod tests_json_map_trait {
 
 #[cfg(test)]
 mod tests_primitive_type_trait {
-    use crate::{
-        json_type::{JsonType, PrimitiveType},
-        traits::_pyo3::perform_python_check,
-    };
+    use super::perform_python_check;
+    use crate::json_type::{JsonType, PrimitiveType};
     use test_case::test_case;
 
     #[test_case("[]", PrimitiveType::Array)]
@@ -372,8 +372,9 @@ mod tests_primitive_type_trait {
 }
 
 #[cfg(test)]
-mod json_map_tests {
-    use crate::{traits::_pyo3::perform_python_check, JsonMapTrait, JsonType};
+mod tests_json_map {
+    use super::perform_python_check;
+    use crate::json_type::{JsonMapTrait, JsonType};
 
     lazy_static! {
         static ref PYTHON_TESTING_MAP_STR: &'static str = "{'key1': {'key2': 1}}";

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -1,5 +1,5 @@
 use crate::{
-    json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
+    json_type::{JsonMap, JsonMapTrait, JsonType, JsonTypeToString, ThreadSafeJsonType, ToRustType},
     rust_type_impl::RustType,
 };
 use serde_json::Value;
@@ -11,6 +11,12 @@ impl Into<RustType> for Value {
 }
 
 impl ToRustType for Value {}
+
+impl JsonTypeToString for Value {
+    fn to_json_string(&self) -> String {
+        self.to_string()
+    }
+}
 
 impl<'json> JsonMapTrait<'json, Value> for JsonMap<'json, Value> {
     #[must_use]
@@ -346,6 +352,28 @@ mod tests_json_map {
         assert_eq!(
             JsonType::as_object(key1).unwrap().items().map(|(k, v)| format!("{} -> {:?}", k, v)).collect::<Vec<_>>(),
             vec![format!("key2 -> {:?}", Value::from(1))],
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests_to_json_string {
+    use crate::json_type::JsonTypeToString;
+
+    #[test]
+    fn smoke_test() {
+        let value = json![[
+            {"array": []},
+            {"boolean": false},
+            {"float": 2.3},
+            {"integer": 1},
+            {"null": null},
+            {"object": {}},
+            {"string": "string"},
+        ]];
+        assert_eq!(
+            value.to_json_string(),
+            r#"[{"array":[]},{"boolean":false},{"float":2.3},{"integer":1},{"null":null},{"object":{}},{"string":"string"}]"#
         );
     }
 }

--- a/src/traits/_serde_json.rs
+++ b/src/traits/_serde_json.rs
@@ -2,16 +2,17 @@ use crate::{
     json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
     rust_type_impl::RustType,
 };
+use serde_json::Value;
 
-impl Into<RustType> for serde_json::Value {
+impl Into<RustType> for Value {
     fn into(self) -> RustType {
         self.to_rust_type()
     }
 }
 
-impl ToRustType for serde_json::Value {}
+impl ToRustType for Value {}
 
-impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json::Value> {
+impl<'json> JsonMapTrait<'json, Value> for JsonMap<'json, Value> {
     #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_object() {
@@ -25,7 +26,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 
     #[must_use]
-    fn values(&'json self) -> Box<dyn Iterator<Item = &serde_json::Value> + 'json> {
+    fn values(&'json self) -> Box<dyn Iterator<Item = &Value> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.values())
         } else {
@@ -37,7 +38,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 
     #[must_use]
-    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &serde_json::Value)> + 'json> {
+    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &Value)> + 'json> {
         if let Some(obj) = self.as_object() {
             Box::new(obj.iter().map(|(k, v)| (k.as_ref(), v)))
         } else {
@@ -49,7 +50,7 @@ impl<'json> JsonMapTrait<'json, serde_json::Value> for JsonMap<'json, serde_json
     }
 }
 
-impl JsonType for serde_json::Value {
+impl JsonType for Value {
     #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_array() {
@@ -113,31 +114,32 @@ impl JsonType for serde_json::Value {
     }
 }
 
-impl ThreadSafeJsonType for serde_json::Value {}
+impl ThreadSafeJsonType for Value {}
 
 #[cfg(test)]
 mod tests_json_map_trait {
-    use crate::{json_type::JsonMap, JsonMapTrait};
+    use crate::json_type::{JsonMap, JsonMapTrait};
+    use serde_json::Value;
 
     lazy_static! {
-        static ref TESTING_MAP: serde_json::Value = json![{"k1": "v1", "k2": "v2"}];
+        static ref TESTING_MAP: Value = json![{"k1": "v1", "k2": "v2"}];
     }
 
     #[test]
     fn keys() {
-        let testing_map: &serde_json::Value = &TESTING_MAP;
+        let testing_map: &Value = &TESTING_MAP;
         assert_eq!(JsonMap::new(testing_map).keys().collect::<Vec<_>>(), vec!["k1", "k2"]);
     }
 
     #[test]
     fn values() {
-        let testing_map: &serde_json::Value = &TESTING_MAP;
+        let testing_map: &Value = &TESTING_MAP;
         assert_eq!(JsonMap::new(testing_map).values().collect::<Vec<_>>(), vec![&json!["v1"], &json!["v2"]]);
     }
 
     #[test]
     fn items() {
-        let testing_map: &serde_json::Value = &TESTING_MAP;
+        let testing_map: &Value = &TESTING_MAP;
         assert_eq!(JsonMap::new(testing_map).items().collect::<Vec<_>>(), vec![("k1", &json!["v1"]), ("k2", &json!["v2"])]);
     }
 }
@@ -145,6 +147,7 @@ mod tests_json_map_trait {
 #[cfg(test)]
 mod tests_primitive_type_trait {
     use crate::json_type::{JsonType, PrimitiveType};
+    use serde_json::Value;
     use std::ops::Deref;
     use test_case::test_case;
 
@@ -155,26 +158,26 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1.2], PrimitiveType::Number)]
     #[test_case(&json![{"prop": "value"}], PrimitiveType::Object)]
     #[test_case(&json!["string"], PrimitiveType::String)]
-    fn test_primitive_type(value: &serde_json::Value, expected_value: PrimitiveType) {
+    fn test_primitive_type(value: &Value, expected_value: PrimitiveType) {
         assert_eq!(JsonType::primitive_type(value), expected_value);
     }
 
     #[test_case(&json![{"present": 1}], "present",  Some(&json![1]))]
     #[test_case(&json![{"present": 1}], "not-present", None)]
-    fn test_get_attribute(value: &serde_json::Value, attribute_name: &str, expected_value: Option<&serde_json::Value>) {
+    fn test_get_attribute(value: &Value, attribute_name: &str, expected_value: Option<&Value>) {
         assert_eq!(JsonType::get_attribute(value, attribute_name), expected_value);
     }
 
     #[test_case(&json![[0, 1, 2]], 1, &Some(json![1]))]
     #[test_case(&json![[0, 1, 2]], 4, &None)]
-    fn test_get_index(value: &serde_json::Value, index: usize, expected_value: &Option<serde_json::Value>) {
+    fn test_get_index(value: &Value, index: usize, expected_value: &Option<Value>) {
         assert_eq!(JsonType::get_index(value, index), expected_value.as_ref());
     }
 
     #[test_case(&json![{"present": 1}], "present", true)]
     #[test_case(&json![{"present": 1}], "not-present", false)]
     #[test_case(&json![[1, 2, 3]], "not-present", false)]
-    fn test_has_attribute(value: &serde_json::Value, attr_name: &str, expected_value: bool) {
+    fn test_has_attribute(value: &Value, attr_name: &str, expected_value: bool) {
         assert_eq!(JsonType::has_attribute(value, attr_name), expected_value);
     }
 
@@ -185,7 +188,7 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1.2_f32], false)]
     #[test_case(&json![{"key": "value"}], false)]
     #[test_case(&json!["string"], false)]
-    fn test_is_array(value: &serde_json::Value, expected_value: bool) {
+    fn test_is_array(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_array(value), expected_value);
     }
 
@@ -196,7 +199,7 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1.2_f32], false)]
     #[test_case(&json![{"key": "value"}], false)]
     #[test_case(&json!["string"], false)]
-    fn test_is_boolean(value: &serde_json::Value, expected_value: bool) {
+    fn test_is_boolean(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_boolean(value), expected_value);
     }
 
@@ -207,7 +210,7 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1.2_f32], false)]
     #[test_case(&json![{"key": "value"}], false)]
     #[test_case(&json!["string"], false)]
-    fn test_is_integer(value: &serde_json::Value, expected_value: bool) {
+    fn test_is_integer(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_integer(value), expected_value);
     }
 
@@ -218,7 +221,7 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1.2_f32], false)]
     #[test_case(&json![{"key": "value"}], false)]
     #[test_case(&json!["string"], false)]
-    fn test_is_null(value: &serde_json::Value, expected_value: bool) {
+    fn test_is_null(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_null(value), expected_value);
     }
 
@@ -229,7 +232,7 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1.2_f32], true)]
     #[test_case(&json![{"key": "value"}], false)]
     #[test_case(&json!["string"], false)]
-    fn test_is_number(value: &serde_json::Value, expected_value: bool) {
+    fn test_is_number(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_number(value), expected_value);
     }
 
@@ -240,7 +243,7 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1.2_f32], false)]
     #[test_case(&json![{"key": "value"}], true)]
     #[test_case(&json!["string"], false)]
-    fn test_is_object(value: &serde_json::Value, expected_value: bool) {
+    fn test_is_object(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_object(value), expected_value);
     }
 
@@ -251,52 +254,52 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1.2_f32], false)]
     #[test_case(&json![{"key": "value"}], false)]
     #[test_case(&json!["string"], true)]
-    fn test_is_string(value: &serde_json::Value, expected_value: bool) {
+    fn test_is_string(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_string(value), expected_value);
     }
 
     #[test_case(&json![[1]], &Some(vec![json![1]]))]
     #[test_case(&json![[1, "a"]], &Some(vec![json![1], json!["a"]]))]
     #[test_case(&json![null], &None)]
-    fn test_as_array(value: &serde_json::Value, expected_value: &Option<Vec<serde_json::Value>>) {
+    fn test_as_array(value: &Value, expected_value: &Option<Vec<Value>>) {
         assert_eq!(&JsonType::as_array(value).map(|iterator| iterator.cloned().collect()), expected_value);
     }
 
     #[test_case(&json![true], Some(true))]
     #[test_case(&json![false], Some(false))]
     #[test_case(&json![1], None)]
-    fn test_as_boolean(value: &serde_json::Value, expected_value: Option<bool>) {
+    fn test_as_boolean(value: &Value, expected_value: Option<bool>) {
         assert_eq!(JsonType::as_boolean(value), expected_value);
     }
 
     #[test_case(&json![1], Some(1))]
     #[test_case(&json![1.2], None)]
     #[test_case(&json!["1"], None)]
-    fn test_as_integer(value: &serde_json::Value, expected_value: Option<i128>) {
+    fn test_as_integer(value: &Value, expected_value: Option<i128>) {
         assert_eq!(JsonType::as_integer(value), expected_value);
     }
 
     #[test_case(&json![null], Some(()))]
     #[test_case(&json!["1"], None)]
-    fn test_as_null(value: &serde_json::Value, expected_value: Option<()>) {
+    fn test_as_null(value: &Value, expected_value: Option<()>) {
         assert_eq!(JsonType::as_null(value), expected_value);
     }
 
     #[test_case(&json![1], Some(1_f64))]
     #[test_case(&json![1.2], Some(1.2))]
     #[test_case(&json!["1"], None)]
-    fn test_as_number(value: &serde_json::Value, expected_value: Option<f64>) {
+    fn test_as_number(value: &Value, expected_value: Option<f64>) {
         assert_eq!(JsonType::as_number(value), expected_value);
     }
 
     #[test_case(&json![1], &None)]
     #[test_case(&json![1.2], &None)]
     #[test_case(&json![{"1": 1}], &Some(json![{"1": 1}]))]
-    fn test_as_object(value: &serde_json::Value, expected_value: &Option<serde_json::Value>) {
+    fn test_as_object(value: &Value, expected_value: &Option<Value>) {
         assert_eq!(
             match JsonType::as_object(value) {
                 Some(ref v) => Some({
-                    #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &serde_json::Value is retrieved from JsonMap
+                    #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &Value is retrieved from JsonMap
                     v.deref()
                 }),
                 None => None,
@@ -308,17 +311,18 @@ mod tests_primitive_type_trait {
     #[test_case(&json![1], None)]
     #[test_case(&json![1.2], None)]
     #[test_case(&json!["1"], Some("1"))]
-    fn test_as_string(value: &serde_json::Value, expected_value: Option<&str>) {
+    fn test_as_string(value: &Value, expected_value: Option<&str>) {
         assert_eq!(JsonType::as_string(value), expected_value);
     }
 }
 
 #[cfg(test)]
-mod json_map_tests {
-    use crate::{json_type::JsonType, JsonMapTrait};
+mod tests_json_map {
+    use crate::json_type::{JsonMapTrait, JsonType};
+    use serde_json::Value;
 
     lazy_static! {
-        static ref TESTING_MAP: serde_json::Value = json![{"key1": {"key2": 1}}];
+        static ref TESTING_MAP: Value = json![{"key1": {"key2": 1}}];
     }
 
     #[test]
@@ -332,7 +336,7 @@ mod json_map_tests {
         let key1 = TESTING_MAP.get_attribute("key1").unwrap();
         assert_eq!(
             JsonType::as_object(key1).unwrap().values().map(|v| format!("{:?}", v)).collect::<Vec<_>>(),
-            vec![format!("{:?}", serde_json::Value::from(1))],
+            vec![format!("{:?}", Value::from(1))],
         );
     }
 
@@ -341,7 +345,7 @@ mod json_map_tests {
         let key1 = TESTING_MAP.get_attribute("key1").unwrap();
         assert_eq!(
             JsonType::as_object(key1).unwrap().items().map(|(k, v)| format!("{} -> {:?}", k, v)).collect::<Vec<_>>(),
-            vec![format!("key2 -> {:?}", serde_json::Value::from(1))],
+            vec![format!("key2 -> {:?}", Value::from(1))],
         );
     }
 }

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -2,16 +2,17 @@ use crate::{
     json_type::{JsonMap, JsonMapTrait, JsonType, ThreadSafeJsonType, ToRustType},
     rust_type_impl::RustType,
 };
+use serde_yaml::Value;
 
-impl Into<RustType> for serde_yaml::Value {
+impl Into<RustType> for Value {
     fn into(self) -> RustType {
         self.to_rust_type()
     }
 }
 
-impl ToRustType for serde_yaml::Value {}
+impl ToRustType for Value {}
 
-impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml::Value> {
+impl<'json> JsonMapTrait<'json, Value> for JsonMap<'json, Value> {
     #[must_use]
     fn keys(&'json self) -> Box<dyn Iterator<Item = &str> + 'json> {
         if let Some(obj) = self.as_mapping() {
@@ -25,7 +26,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 
     #[must_use]
-    fn values(&'json self) -> Box<dyn Iterator<Item = &serde_yaml::Value> + 'json> {
+    fn values(&'json self) -> Box<dyn Iterator<Item = &Value> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(_, value)| value))
         } else {
@@ -37,7 +38,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 
     #[must_use]
-    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &serde_yaml::Value)> + 'json> {
+    fn items(&'json self) -> Box<dyn Iterator<Item = (&str, &Value)> + 'json> {
         if let Some(obj) = self.as_mapping() {
             Box::new(obj.iter().map(|(key, value)| (key.as_str().unwrap(), value)))
         } else {
@@ -49,7 +50,7 @@ impl<'json> JsonMapTrait<'json, serde_yaml::Value> for JsonMap<'json, serde_yaml
     }
 }
 
-impl JsonType for serde_yaml::Value {
+impl JsonType for Value {
     #[must_use]
     fn as_array<'json>(&'json self) -> Option<Box<dyn ExactSizeIterator<Item = &Self> + 'json>> {
         if let Some(vec) = self.as_sequence() {
@@ -113,13 +114,14 @@ impl JsonType for serde_yaml::Value {
     }
 }
 
-impl ThreadSafeJsonType for serde_yaml::Value {}
+impl ThreadSafeJsonType for Value {}
 
 #[cfg(test)]
 macro_rules! yaml {
     ($($json:tt)+) => {{
         use serde_json;
         use serde_yaml;
+        #[allow(unused_qualifications)]
         let thing: serde_yaml::Value = serde_yaml::from_str(
             serde_json::to_string(&json![$($json)+]).unwrap().as_str(),
         ).unwrap();
@@ -130,26 +132,27 @@ macro_rules! yaml {
 #[cfg(test)]
 mod tests_yaml_map_trait {
     use crate::json_type::{JsonMap, JsonMapTrait};
+    use serde_yaml::Value;
 
     lazy_static! {
-        static ref TESTING_MAP: serde_yaml::Value = yaml![{"k1": "v1", "k2": "v2"}];
+        static ref TESTING_MAP: Value = yaml![{"k1": "v1", "k2": "v2"}];
     }
 
     #[test]
     fn keys() {
-        let testing_map: &serde_yaml::Value = &TESTING_MAP;
+        let testing_map: &Value = &TESTING_MAP;
         assert_eq!(JsonMap::new(testing_map).keys().collect::<Vec<_>>(), vec!["k1", "k2"]);
     }
 
     #[test]
     fn values() {
-        let testing_map: &serde_yaml::Value = &TESTING_MAP;
+        let testing_map: &Value = &TESTING_MAP;
         assert_eq!(JsonMap::new(testing_map).values().collect::<Vec<_>>(), vec![&yaml!["v1"], &yaml!["v2"]]);
     }
 
     #[test]
     fn items() {
-        let testing_map: &serde_yaml::Value = &TESTING_MAP;
+        let testing_map: &Value = &TESTING_MAP;
         assert_eq!(JsonMap::new(testing_map).items().collect::<Vec<_>>(), vec![("k1", &yaml!["v1"]), ("k2", &yaml!["v2"])]);
     }
 }
@@ -157,6 +160,7 @@ mod tests_yaml_map_trait {
 #[cfg(test)]
 mod tests_primitive_type_trait {
     use crate::json_type::{JsonType, PrimitiveType};
+    use serde_yaml::Value;
     use std::ops::Deref;
     use test_case::test_case;
 
@@ -167,26 +171,26 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1.2], PrimitiveType::Number)]
     #[test_case(&yaml![{"prop": "value"}], PrimitiveType::Object)]
     #[test_case(&yaml!["string"], PrimitiveType::String)]
-    fn test_primitive_type(value: &serde_yaml::Value, expected_value: PrimitiveType) {
+    fn test_primitive_type(value: &Value, expected_value: PrimitiveType) {
         assert_eq!(JsonType::primitive_type(value), expected_value);
     }
 
     #[test_case(&yaml![{"present": 1}], "present", Some(&yaml![1]))]
     #[test_case(&yaml![{"present": 1}], "not-present", None)]
-    fn test_get_attribute(value: &serde_yaml::Value, attribute_name: &str, expected_value: Option<&serde_yaml::Value>) {
+    fn test_get_attribute(value: &Value, attribute_name: &str, expected_value: Option<&Value>) {
         assert_eq!(JsonType::get_attribute(value, attribute_name), expected_value);
     }
 
     #[test_case(&yaml![[0, 1, 2]], 1, &Some(yaml![1]))]
     #[test_case(&yaml![[0, 1, 2]], 4, &None)]
-    fn test_get_index(value: &serde_yaml::Value, index: usize, expected_value: &Option<serde_yaml::Value>) {
+    fn test_get_index(value: &Value, index: usize, expected_value: &Option<Value>) {
         assert_eq!(JsonType::get_index(value, index), expected_value.as_ref());
     }
 
     #[test_case(&yaml![{"present": 1}], "present", true)]
     #[test_case(&yaml![{"present": 1}], "not-present", false)]
     #[test_case(&yaml![[1, 2, 3]], "not-present", false)]
-    fn test_has_attribute(value: &serde_yaml::Value, attr_name: &str, expected_value: bool) {
+    fn test_has_attribute(value: &Value, attr_name: &str, expected_value: bool) {
         assert_eq!(JsonType::has_attribute(value, attr_name), expected_value);
     }
 
@@ -197,7 +201,7 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1.2_f32], false)]
     #[test_case(&yaml![{"key": "value"}], false)]
     #[test_case(&yaml!["string"], false)]
-    fn test_is_array(value: &serde_yaml::Value, expected_value: bool) {
+    fn test_is_array(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_array(value), expected_value);
     }
 
@@ -208,7 +212,7 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1.2_f32], false)]
     #[test_case(&yaml![{"key": "value"}], false)]
     #[test_case(&yaml!["string"], false)]
-    fn test_is_boolean(value: &serde_yaml::Value, expected_value: bool) {
+    fn test_is_boolean(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_boolean(value), expected_value);
     }
 
@@ -219,7 +223,7 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1.2_f32], false)]
     #[test_case(&yaml![{"key": "value"}], false)]
     #[test_case(&yaml!["string"], false)]
-    fn test_is_integer(value: &serde_yaml::Value, expected_value: bool) {
+    fn test_is_integer(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_integer(value), expected_value);
     }
 
@@ -230,7 +234,7 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1.2_f32], false)]
     #[test_case(&yaml![{"key": "value"}], false)]
     #[test_case(&yaml!["string"], false)]
-    fn test_is_null(value: &serde_yaml::Value, expected_value: bool) {
+    fn test_is_null(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_null(value), expected_value);
     }
 
@@ -241,7 +245,7 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1.2_f32], true)]
     #[test_case(&yaml![{"key": "value"}], false)]
     #[test_case(&yaml!["string"], false)]
-    fn test_is_number(value: &serde_yaml::Value, expected_value: bool) {
+    fn test_is_number(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_number(value), expected_value);
     }
 
@@ -252,7 +256,7 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1.2_f32], false)]
     #[test_case(&yaml![{"key": "value"}], true)]
     #[test_case(&yaml!["string"], false)]
-    fn test_is_object(value: &serde_yaml::Value, expected_value: bool) {
+    fn test_is_object(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_object(value), expected_value);
     }
 
@@ -263,52 +267,52 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1.2_f32], false)]
     #[test_case(&yaml![{"key": "value"}], false)]
     #[test_case(&yaml!["string"], true)]
-    fn test_is_string(value: &serde_yaml::Value, expected_value: bool) {
+    fn test_is_string(value: &Value, expected_value: bool) {
         assert_eq!(JsonType::is_string(value), expected_value);
     }
 
     #[test_case(&yaml![[1]], &Some(vec![yaml![1]]))]
     #[test_case(&yaml![[1, "a"]], &Some(vec![yaml![1], yaml!["a"]]))]
     #[test_case(&yaml![null], &None)]
-    fn test_as_array(value: &serde_yaml::Value, expected_value: &Option<Vec<serde_yaml::Value>>) {
+    fn test_as_array(value: &Value, expected_value: &Option<Vec<Value>>) {
         assert_eq!(&JsonType::as_array(value).map(|iterator| iterator.cloned().collect()), expected_value);
     }
 
     #[test_case(&yaml![true], Some(true))]
     #[test_case(&yaml![false], Some(false))]
     #[test_case(&yaml![1], None)]
-    fn test_as_boolean(value: &serde_yaml::Value, expected_value: Option<bool>) {
+    fn test_as_boolean(value: &Value, expected_value: Option<bool>) {
         assert_eq!(JsonType::as_boolean(value), expected_value);
     }
 
     #[test_case(&yaml![1], Some(1))]
     #[test_case(&yaml![1.2], None)]
     #[test_case(&yaml!["1"], None)]
-    fn test_as_integer(value: &serde_yaml::Value, expected_value: Option<i128>) {
+    fn test_as_integer(value: &Value, expected_value: Option<i128>) {
         assert_eq!(JsonType::as_integer(value), expected_value);
     }
 
     #[test_case(&yaml![null], Some(()))]
     #[test_case(&yaml!["1"], None)]
-    fn test_as_null(value: &serde_yaml::Value, expected_value: Option<()>) {
+    fn test_as_null(value: &Value, expected_value: Option<()>) {
         assert_eq!(JsonType::as_null(value), expected_value);
     }
 
     #[test_case(&yaml![1], Some(1_f64))]
     #[test_case(&yaml![1.2], Some(1.2))]
     #[test_case(&yaml!["1"], None)]
-    fn test_as_number(value: &serde_yaml::Value, expected_value: Option<f64>) {
+    fn test_as_number(value: &Value, expected_value: Option<f64>) {
         assert_eq!(JsonType::as_number(value), expected_value);
     }
 
     #[test_case(&yaml![1], &None)]
     #[test_case(&yaml![1.2], &None)]
     #[test_case(&yaml![{"1": 1}], &Some(yaml![{"1": 1}]))]
-    fn test_as_object(value: &serde_yaml::Value, expected_value: &Option<serde_yaml::Value>) {
+    fn test_as_object(value: &Value, expected_value: &Option<Value>) {
         assert_eq!(
             match JsonType::as_object(value) {
                 Some(ref v) => Some({
-                    #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &serde_yaml::Value is retrieved from JsonMap
+                    #[allow(clippy::explicit_deref_methods)] // Explicit deref call is needed to ensure that &Value is retrieved from JsonMap
                     v.deref()
                 }),
                 None => None,
@@ -320,22 +324,23 @@ mod tests_primitive_type_trait {
     #[test_case(&yaml![1], None)]
     #[test_case(&yaml![1.2], None)]
     #[test_case(&yaml!["1"], Some("1"))]
-    fn test_as_string(value: &serde_yaml::Value, expected_value: Option<&str>) {
+    fn test_as_string(value: &Value, expected_value: Option<&str>) {
         assert_eq!(JsonType::as_string(value), expected_value);
     }
 }
 
 #[cfg(test)]
-mod json_map_tests {
-    use crate::{json_type::JsonType, JsonMapTrait};
+mod tests_json_map {
+    use crate::json_type::{JsonMapTrait, JsonType};
+    use serde_yaml::Value;
 
     lazy_static! {
-        static ref TESTING_MAP: serde_yaml::Value = yaml![{"key1": {"key2": 1}}];
+        static ref TESTING_MAP: Value = yaml![{"key1": {"key2": 1}}];
     }
 
     #[test]
     fn test_keys() {
-        let key1: &serde_yaml::Value = TESTING_MAP.get_attribute("key1").unwrap();
+        let key1: &Value = TESTING_MAP.get_attribute("key1").unwrap();
         assert_eq!(JsonType::as_object(key1).unwrap().keys().collect::<Vec<_>>(), vec![String::from("key2")]);
     }
 
@@ -344,7 +349,7 @@ mod json_map_tests {
         let key1 = TESTING_MAP.get_attribute("key1").unwrap();
         assert_eq!(
             JsonType::as_object(key1).unwrap().values().map(|v| format!("{:?}", v)).collect::<Vec<_>>(),
-            vec![format!("{:?}", serde_yaml::Value::from(1))],
+            vec![format!("{:?}", Value::from(1))],
         );
     }
 
@@ -353,7 +358,7 @@ mod json_map_tests {
         let key1 = TESTING_MAP.get_attribute("key1").unwrap();
         assert_eq!(
             JsonType::as_object(key1).unwrap().items().map(|(k, v)| format!("{} -> {:?}", k, v)).collect::<Vec<_>>(),
-            vec![format!("key2 -> {:?}", serde_yaml::Value::from(1))],
+            vec![format!("key2 -> {:?}", Value::from(1))],
         );
     }
 }

--- a/src/traits/_serde_yaml.rs
+++ b/src/traits/_serde_yaml.rs
@@ -362,3 +362,25 @@ mod tests_json_map {
         );
     }
 }
+
+#[cfg(test)]
+mod tests_to_json_string {
+    use crate::json_type::JsonTypeToString;
+
+    #[test]
+    fn smoke_test() {
+        let value = yaml![[
+            {"array": []},
+            {"boolean": false},
+            {"float": 2.3},
+            {"integer": 1},
+            {"null": null},
+            {"object": {}},
+            {"string": "string"},
+        ]];
+        assert_eq!(
+            value.to_json_string(),
+            r#"[{"array":[]},{"boolean":false},{"float":2.3},{"integer":1},{"null":null},{"object":{}},{"string":"string"}]"#
+        );
+    }
+}


### PR DESCRIPTION
The goal of this PR is to ensure that :
 * `JsonType` instances are not forced to be `Debug` types
 * `JsonType` instances are ensured to be string-representable via a new trait (`JsonTypeToString`)

NOTE: `JsonTypeToString` does provide a default implementation but different trait implementations might override its implementation to use more performant solutions
