### PR TITLE
Use thiserror instead of the deprecated failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = "1"
 test-case = "1"
 
 [dependencies]
-failure = "0"
+thiserror = "1"
 join-lazy-fmt = "0"
 json = { version = "0", optional = true }
 pyo3 = { version = "0", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
-use failure::Fail;
-#[derive(Debug, Fail, PartialEq)]
+use thiserror::Error;
+#[derive(Debug, Error, PartialEq)]
 pub enum Error {
-    #[fail(display = "Unsupported primitive type `{}`. Available types are defined by `json_trait_rs::PrimitiveType::VARIANTS`", type_str)]
+    #[error("Unsupported primitive type `{type_str}`. Available types are defined by `json_trait_rs::PrimitiveType::VARIANTS`")]
     UnsupportedPrimitiveType { type_str: String },
 }


### PR DESCRIPTION
By migrating to standard `Error`, `Box<dyn Error>` become usable along errors from other crates. in the future it also helps that we can put any errors that implements `Error` as cause/underlying error of our error.